### PR TITLE
Create Real type

### DIFF
--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+
 // IDE configuration: This file will contain some redundant casts because it's
 // designed to allow a field type to be changed to change the behavior of
 // the rest of the file. Other IDEs with different "disable for file"
@@ -23,70 +24,69 @@ using System;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
-    /// <summary>
-    /// Struct <c>Real</c> wraps a floating-point representation, which can be changed at compile time to reveal
-    /// numerical instability problems (by using float) or to minimize them (by using double). It also offers a window
-    /// to add debugging hooks for math during development, watch for numerical instability, etc.
-    /// </summary>
-    public struct Real : IComparable<Real>, IEquatable<Real>, IFormattable
-    {
-        /// <summary>
-        /// _v contains the value represented by this Real. To change the effective type of Real,
-        /// change the type of this and the special constants below the constructors.
-        /// </summary>
-        private readonly double _v;
+	/// <summary>
+	/// Struct <c>Real</c> wraps a floating-point representation, which can be changed at compile time to reveal
+	/// numerical instability problems (by using float) or to minimize them (by using double). It also offers a window
+	/// to add debugging hooks for math during development, watch for numerical instability, etc.
+	/// </summary>
+	public struct Real : IComparable<Real>, IEquatable<Real>, IFormattable
+	{
+		/// <summary>
+		/// _v contains the value represented by this Real. To change the effective type of Real,
+		/// change the type of this and the special constants below the constructors.
+		/// </summary>
+		private readonly double _v;
 
-        #pragma mark Constructors
-        /// <summary>
-        /// Construct a Real with the value provided.
-        /// </summary>
-        /// <param name="v">Value this Real should take.</param>
-        public Real(double v)
-        {
-            _v = v;
-        }
+#pragma mark Constructors
+		/// <summary>
+		/// Construct a Real with the value provided.
+		/// </summary>
+		/// <param name="v">Value this Real should take.</param>
+		public Real(double v)
+		{
+			_v = v;
+		}
 
-        /// <summary>
-        /// Construct a Real with the value provided.
-        /// </summary>
-        /// <param name="v">Value this Real should take.</param>
-        public Real(float v)
-        {
-            _v = v;
-        }
+		/// <summary>
+		/// Construct a Real with the value provided.
+		/// </summary>
+		/// <param name="v">Value this Real should take.</param>
+		public Real(float v)
+		{
+			_v = v;
+		}
 
-        /// <summary>
-        /// Construct a Real with the value provided.
-        /// </summary>
-        /// <param name="v">Value this Real should take.</param>
-        public Real(decimal v)
-        {
-            _v = (double)v;
-        }
+		/// <summary>
+		/// Construct a Real with the value provided.
+		/// </summary>
+		/// <param name="v">Value this Real should take.</param>
+		public Real(decimal v)
+		{
+			_v = (double) v;
+		}
 
-        #pragma mark Conversions
-        // Real permits automatic casts <i>from</i> double, float, and decimal. It will not
-        // automatically cast to them, since this would prevent the compiler from spotting math
-        // being done with native numeric types that needs to be converted to Real.
-        public static implicit operator Real(double d) => new Real(d);
-        public static implicit operator Real(float f) => new Real(f);
-        public static implicit operator Real(decimal m) => new Real(m);
-        public static explicit operator double(Real r) => (double)r._v;
-        public static explicit operator float(Real r) => (float)r._v;
-        public static explicit operator decimal(Real r) => (decimal) r._v;
+#pragma mark Conversions
+		// Real permits automatic casts <i>from</i> double, float, and decimal. It will not
+		// automatically cast to them, since this would prevent the compiler from spotting math
+		// being done with native numeric types that needs to be converted to Real.
+		public static implicit operator Real(double d) => new Real(d);
+		public static implicit operator Real(float f) => new Real(f);
+		public static implicit operator Real(decimal m) => new Real(m);
+		public static explicit operator double(Real r) => (double) r._v;
+		public static explicit operator float(Real r) => (float) r._v;
+		public static explicit operator decimal(Real r) => (decimal) r._v;
 
-        #pragma mark Interfaces
-        public string ToString(string format, IFormatProvider formatProvider)
-        {
-            return _v.ToString(format, formatProvider);
-        }
+#pragma mark Interfaces
+		public string ToString(string format, IFormatProvider formatProvider)
+		{
+			return _v.ToString(format, formatProvider);
+		}
 
-        public int CompareTo(Real o) => _v.CompareTo(o._v);
+		public int CompareTo(Real o) => _v.CompareTo(o._v);
 
-        public bool Equals(Real o)
-        {
-            return _v.Equals(o._v);
-        }
-
-    }
+		public bool Equals(Real o)
+		{
+			return _v.Equals(o._v);
+		}
+	}
 }

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -52,7 +52,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
         /// <param name="v">Value this Real should take.</param>
         public Real(decimal v)
         {
-            _v = v;
+            _v = (double)v;
         }
 
         // Real permits automatic casts <i>from</i> double, float, and decimal. It will not

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.ComponentModel.Design.Serialization;
+using System.Runtime.CompilerServices;
 
 // IDE configuration: This file will contain some redundant casts because it's
 // designed to allow a field type to be changed to change the behavior of
@@ -114,5 +116,115 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		{
 			return _v.Equals(o._v);
 		}
+
+		public override bool Equals(object o)
+		{
+			switch (o)
+			{
+				case null:
+					return false;
+				case Real real:
+					return this.Equals(real);
+				default:
+					return false;
+			}
+		}
+
+		public override int GetHashCode()
+		{
+			int h = _v.GetHashCode();
+			return ~(h << 16 | h >> 16);
+		}
+#pragma mark Special value properties
+		public bool IsNaN
+		{
+			get
+			{
+#if REALTYPE_DOUBLE
+				return double.IsNaN(_v);
+#elif REALTYPE_FLOAT
+				return float.IsNaN(_v);
+#elif REALTYPE_DECIMAL
+				return false;
+#else
+				#error Real doesn't know how to calculate IsNaN for its current type.
+#endif
+			}
+		}
+
+		public bool IsInfinity
+		{
+			get
+			{
+#if REALTYPE_DOUBLE
+				return double.IsInfinity(_v);
+#elif REALTYPE_FLOAT
+				return float.IsInfinity(_v);
+#elif REALTYPE_DECIMAL
+				return false;
+#else
+				#error Real doesn't know how to calculate IsInfinity for its current type.
+#endif
+			}
+		}
+
+		public bool IsPositiveInfinity
+		{
+			get
+			{
+#if REALTYPE_DOUBLE
+				return double.IsPositiveInfinity(_v);
+#elif REALTYPE_FLOAT
+				return float.IsPositiveInfinity(_v);
+#elif REALTYPE_DECIMAL
+				return false;
+#else
+#error Real doesn't know how to calculate IsPositiveInfinity for its current type.
+#endif
+			}
+		}
+
+		public bool IsNegativeInfinity
+		{
+			get
+			{
+#if REALTYPE_DOUBLE
+				return double.IsNegativeInfinity(_v);
+#elif REALTYPE_FLOAT
+				return float.IsNegativeInfinity(_v);
+#elif REALTYPE_DECIMAL
+				return false;
+#else
+#error Real doesn't know how to calculate IsNegativeInfinity for its current type.
+#endif
+			}
+		}
+
+		public bool IsFinite => !IsInfinity && !IsNaN;
+
+#pragma mark Unary operators
+		// Note: NaN is neither true nor false.
+		public static bool operator true(Real r) => r._v == 0;
+		public static bool operator false(Real r) => r._v != 0;
+
+		public static Real operator !(Real r)
+		{
+			if (r.IsNaN)
+			{
+				return Real.NaN;
+			}
+
+			if (r._v == 0)
+			{
+				return new Real(1.0);
+			}
+
+			return new Real(0.0);
+		}
+
+		public static Real operator +(Real r) => r;
+		public static Real operator -(Real r) => new Real(-r._v);
+		public static Real operator ++(Real r) => new Real(r._v + 1);
+		public static Real operator --(Real r) => new Real(r._v - 1);
 	}
 }

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -205,12 +205,21 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static bool operator true(Real r) => r._v == 0;
 		public static bool operator false(Real r) => r._v != 0;
 
+		/// <summary>
+		/// Implements logical inversion on a floating-point value, extending the semantics of
+		/// C# to do so. NaN values remain NaN. Otherwise, positive and negative zero both
+		/// become 1.0, and all nonzero non-NaN values become 0.0.
+		/// </summary>
+		/// <param name="r">Value to invert.</param>
+		/// <returns>Logical inversion of <c>r</c>. NaN remains NaN.</returns>
 		public static Real operator !(Real r)
 		{
+			#if !REALTYPE_DECIMAL
 			if (r.IsNaN)
 			{
 				return Real.NaN;
 			}
+			#endif
 
 			if (r._v == 0)
 			{

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -60,7 +60,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		#error No known underlying type for Real - see Real.cs for details
 #endif
 
-#pragma mark Constructors
+#pragma region Constructors
 		/// <summary>
 		/// Construct a Real with the value provided.
 		/// </summary>
@@ -104,7 +104,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 #endif
 		}
 
-#pragma mark Constants
+#pragma region Constants
 #if REALTYPE_DOUBLE
 		public static readonly Real NaN = new Real(double.NaN);
 		public static readonly Real NegativeInfinity = new Real(double.NegativeInfinity);
@@ -119,7 +119,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		#error No known source of constants for Real
 #endif
 
-#pragma mark Conversions
+#pragma region Conversions
 		// Real permits automatic casts <i>from</i> double, float, and decimal. It will not
 		// automatically cast to them, since this would prevent the compiler from spotting math
 		// being done with native numeric types that needs to be converted to Real.
@@ -130,7 +130,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static explicit operator float(Real r) => (float) r._v;
 		public static explicit operator decimal(Real r) => (decimal) r._v;
 
-#pragma mark Interfaces
+#pragma region Interfaces
 		public string ToString(string format, IFormatProvider formatProvider)
 		{
 			return _v.ToString(format, formatProvider);
@@ -161,7 +161,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 			int h = _v.GetHashCode();
 			return ~(h << 16 | h >> 16);
 		}
-#pragma mark Special value properties
+#pragma region Special value properties
 		public bool IsNaN
 		{
 			get
@@ -228,7 +228,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 
 		public bool IsFinite => !IsInfinity && !IsNaN;
 
-#pragma mark Unary operators
+#pragma region Unary operators
 		// Note: NaN is neither true nor false.
 		public static bool operator true(Real r) => r._v == 0;
 		public static bool operator false(Real r) => r._v != 0;
@@ -262,13 +262,13 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static Real operator ++(Real r) => new Real(r._v + 1);
 		public static Real operator --(Real r) => new Real(r._v - 1);
 
-#pragma mark Binary arithmetic operators
+#pragma region Binary arithmetic operators
 		public static Real operator +(Real left, Real right) => new Real(right._v + left._v);
 		public static Real operator -(Real left, Real right) => new Real(left._v - right._v);
 		public static Real operator *(Real left, Real right) => new Real(left._v * right._v);
 		public static Real operator /(Real left, Real right) => new Real(left._v / right._v);
 		public static Real operator %(Real left, Real right) => new Real(left._v % right._v);
-#pragma mark Binary comparison operators
+#pragma region Binary comparison operators
 		public static bool operator <(Real left, Real right) => left._v < right._v;
 		public static bool operator >(Real left, Real right) => left._v > right._v;
 		public static bool operator ==(Real left, Real right) => left._v == right._v;

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -15,8 +15,6 @@
  */
 
 using System;
-using System.ComponentModel.Design.Serialization;
-using System.Runtime.CompilerServices;
 
 // IDE configuration: This file will contain some redundant casts because it's
 // designed to allow a field type to be changed to change the behavior of

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -233,5 +233,19 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static Real operator -(Real r) => new Real(-r._v);
 		public static Real operator ++(Real r) => new Real(r._v + 1);
 		public static Real operator --(Real r) => new Real(r._v - 1);
+
+#pragma mark Binary arithmetic operators
+		public static Real operator +(Real left, Real right) => new Real(right._v + left._v);
+		public static Real operator -(Real left, Real right) => new Real(left._v - right._v);
+		public static Real operator *(Real left, Real right) => new Real(left._v * right._v);
+		public static Real operator /(Real left, Real right) => new Real(left._v / right._v);
+		public static Real operator %(Real left, Real right) => new Real(left._v % right._v);
+#pragma mark Binary comparison operators
+		public static bool operator <(Real left, Real right) => left._v < right._v;
+		public static bool operator >(Real left, Real right) => left._v > right._v;
+		public static bool operator ==(Real left, Real right) => left._v == right._v;
+		public static bool operator !=(Real left, Real right) => left._v != right._v;
+		public static bool operator <=(Real left, Real right) => left._v <= right._v;
+		public static bool operator >=(Real left, Real right) => left._v >= right._v;
 	}
 }

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -13,6 +13,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+
+using System;
+// IDE configuration: This file will contain some redundant casts because it's
+// designed to allow a field type to be changed to change the behavior of
+// the rest of the file. Other IDEs with different "disable for file"
+// comment syntax should put those disables here.
+// ReSharper disable RedundantCast
+
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
     /// <summary>
@@ -20,14 +28,15 @@ namespace FreedomOfFormFoundation.AnatomyEngine
     /// numerical instability problems (by using float) or to minimize them (by using double). It also offers a window
     /// to add debugging hooks for math during development, watch for numerical instability, etc.
     /// </summary>
-    public struct Real
+    public struct Real : IComparable<Real>, IEquatable<Real>, IFormattable
     {
         /// <summary>
-        /// _v contains the value represented by this Real. To change the effective type of Real, change the type
-        /// of this declaration.
+        /// _v contains the value represented by this Real. To change the effective type of Real,
+        /// change the type of this and the special constants below the constructors.
         /// </summary>
-        private double _v;
+        private readonly double _v;
 
+        #pragma mark Constructors
         /// <summary>
         /// Construct a Real with the value provided.
         /// </summary>
@@ -55,6 +64,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
             _v = (double)v;
         }
 
+        #pragma mark Conversions
         // Real permits automatic casts <i>from</i> double, float, and decimal. It will not
         // automatically cast to them, since this would prevent the compiler from spotting math
         // being done with native numeric types that needs to be converted to Real.
@@ -64,5 +74,19 @@ namespace FreedomOfFormFoundation.AnatomyEngine
         public static explicit operator double(Real r) => (double)r._v;
         public static explicit operator float(Real r) => (float)r._v;
         public static explicit operator decimal(Real r) => (decimal) r._v;
+
+        #pragma mark Interfaces
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return _v.ToString(format, formatProvider);
+        }
+
+        public int CompareTo(Real o) => _v.CompareTo(o._v);
+
+        public bool Equals(Real o)
+        {
+            return _v.Equals(o._v);
+        }
+
     }
 }

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -60,7 +60,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		#error No known underlying type for Real - see Real.cs for details
 #endif
 
-#pragma region Constructors
+#region Constructors
 		/// <summary>
 		/// Construct a Real with the value provided.
 		/// </summary>
@@ -103,8 +103,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 			#error Real doesn't know how to cast from decimal
 #endif
 		}
-
-#pragma region Constants
+#endregion
+#region Constants
 #if REALTYPE_DOUBLE
 		public static readonly Real NaN = new Real(double.NaN);
 		public static readonly Real NegativeInfinity = new Real(double.NegativeInfinity);
@@ -118,8 +118,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 #else
 		#error No known source of constants for Real
 #endif
-
-#pragma region Conversions
+#endregion
+#region Conversions
 		// Real permits automatic casts <i>from</i> double, float, and decimal. It will not
 		// automatically cast to them, since this would prevent the compiler from spotting math
 		// being done with native numeric types that needs to be converted to Real.
@@ -129,8 +129,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static explicit operator double(Real r) => (double) r._v;
 		public static explicit operator float(Real r) => (float) r._v;
 		public static explicit operator decimal(Real r) => (decimal) r._v;
-
-#pragma region Interfaces
+#endregion
+#region Interfaces
 		public string ToString(string format, IFormatProvider formatProvider)
 		{
 			return _v.ToString(format, formatProvider);
@@ -161,7 +161,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 			int h = _v.GetHashCode();
 			return ~(h << 16 | h >> 16);
 		}
-#pragma region Special value properties
+#endregion
+#region Special value properties
 		public bool IsNaN
 		{
 			get
@@ -227,8 +228,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		}
 
 		public bool IsFinite => !IsInfinity && !IsNaN;
-
-#pragma region Unary operators
+#endregion
+#region Unary operators
 		// Note: NaN is neither true nor false.
 		public static bool operator true(Real r) => r._v == 0;
 		public static bool operator false(Real r) => r._v != 0;
@@ -261,19 +262,21 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		public static Real operator -(Real r) => new Real(-r._v);
 		public static Real operator ++(Real r) => new Real(r._v + 1);
 		public static Real operator --(Real r) => new Real(r._v - 1);
-
-#pragma region Binary arithmetic operators
+#endregion
+#region Binary arithmetic operators
 		public static Real operator +(Real left, Real right) => new Real(right._v + left._v);
 		public static Real operator -(Real left, Real right) => new Real(left._v - right._v);
 		public static Real operator *(Real left, Real right) => new Real(left._v * right._v);
 		public static Real operator /(Real left, Real right) => new Real(left._v / right._v);
 		public static Real operator %(Real left, Real right) => new Real(left._v % right._v);
-#pragma region Binary comparison operators
+#endregion
+#region Binary comparison operators
 		public static bool operator <(Real left, Real right) => left._v < right._v;
 		public static bool operator >(Real left, Real right) => left._v > right._v;
 		public static bool operator ==(Real left, Real right) => left._v == right._v;
 		public static bool operator !=(Real left, Real right) => left._v != right._v;
 		public static bool operator <=(Real left, Real right) => left._v <= right._v;
 		public static bool operator >=(Real left, Real right) => left._v >= right._v;
+#endregion
 	}
 }

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -24,6 +24,13 @@ using System;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
+	// Default implementation is DOUBLE but it can be overridden by the compiler.
+	// Specify exactly one of these flags.
+	// Warning: Decimal can't represent infinity or NaN, so using these
+	// constants won't compile if Real is Decimal.
+#if !REALTYPE_DOUBLE && !REALTYPE_FLOAT && !REALTYPE_DECIMAL
+#define REALTYPE_DOUBLE
+#endif
 	/// <summary>
 	/// Struct <c>Real</c> wraps a floating-point representation, which can be changed at compile time to reveal
 	/// numerical instability problems (by using float) or to minimize them (by using double). It also offers a window
@@ -31,11 +38,15 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 	/// </summary>
 	public struct Real : IComparable<Real>, IEquatable<Real>, IFormattable
 	{
-		/// <summary>
-		/// _v contains the value represented by this Real. To change the effective type of Real,
-		/// change the type of this and the special constants below the constructors.
-		/// </summary>
+#if REALTYPE_DOUBLE
 		private readonly double _v;
+#elif REALTYPE_FLOAT
+		private readonly float _v;
+#elif REALTYPE_DECIMAL
+		private readonly decimal _v;
+#else
+		#error No known underlying type for Real - see Real.cs for details
+#endif
 
 #pragma mark Constructors
 		/// <summary>
@@ -64,6 +75,21 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		{
 			_v = (double) v;
 		}
+
+#pragma mark Constants
+#if REALTYPE_DOUBLE
+		public static readonly Real NaN = new Real(double.NaN);
+		public static readonly Real NegativeInfinity = new Real(double.NegativeInfinity);
+		public static readonly Real PositiveInfinity = new Real(double.PositiveInfinity);
+#elif REALTYPE_FLOAT
+		public static readonly Real NaN = new Real(float.NaN);
+		public static readonly Real NegativeInfinity = new Real(float.NegativeInfinity);
+		public static readonly Real PositiveInfinity = new Real(float.PositiveInfinity);
+#elif REALTYPE_DECIMAL
+		#warning No definition of NaN, NegativeInfinity, or PositiveInfinity available from decimal
+#else
+		#error No known source of constants for Real
+#endif
 
 #pragma mark Conversions
 		// Real permits automatic casts <i>from</i> double, float, and decimal. It will not

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ * 
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+namespace FreedomOfFormFoundation.AnatomyEngine
+{
+    /// <summary>
+    /// Struct <c>Real</c> wraps a floating-point representation, which can be changed at compile time to reveal
+    /// numerical instability problems (by using float) or to minimize them (by using double). It also offers a window
+    /// to add debugging hooks for math during development, watch for numerical instability, etc.
+    /// </summary>
+    public struct Real
+    {
+        /// <summary>
+        /// _v contains the value represented by this Real. To change the effective type of Real, change the type
+        /// of this declaration.
+        /// </summary>
+        private double _v;
+
+        public Real(double v)
+        {
+            _v = v;
+        }
+
+        // Real permits automatic casts <i>from</i> double and float. It will not automatically cast to them, since
+        // this would prevent the compiler from spotting math being done with native numeric types that needs to
+        // be converted to Real.
+        public static implicit operator Real(double d) => new Real(d);
+        public static implicit operator Real(float f) => new Real(f);
+        public static explicit operator double(Real r) => (double)r._v;
+        public static explicit operator float(Real r) => (float)r._v;
+    }
+}

--- a/engine/Real.cs
+++ b/engine/Real.cs
@@ -28,17 +28,41 @@ namespace FreedomOfFormFoundation.AnatomyEngine
         /// </summary>
         private double _v;
 
+        /// <summary>
+        /// Construct a Real with the value provided.
+        /// </summary>
+        /// <param name="v">Value this Real should take.</param>
         public Real(double v)
         {
             _v = v;
         }
 
-        // Real permits automatic casts <i>from</i> double and float. It will not automatically cast to them, since
-        // this would prevent the compiler from spotting math being done with native numeric types that needs to
-        // be converted to Real.
+        /// <summary>
+        /// Construct a Real with the value provided.
+        /// </summary>
+        /// <param name="v">Value this Real should take.</param>
+        public Real(float v)
+        {
+            _v = v;
+        }
+
+        /// <summary>
+        /// Construct a Real with the value provided.
+        /// </summary>
+        /// <param name="v">Value this Real should take.</param>
+        public Real(decimal v)
+        {
+            _v = v;
+        }
+
+        // Real permits automatic casts <i>from</i> double, float, and decimal. It will not
+        // automatically cast to them, since this would prevent the compiler from spotting math
+        // being done with native numeric types that needs to be converted to Real.
         public static implicit operator Real(double d) => new Real(d);
         public static implicit operator Real(float f) => new Real(f);
+        public static implicit operator Real(decimal m) => new Real(m);
         public static explicit operator double(Real r) => (double)r._v;
         public static explicit operator float(Real r) => (float)r._v;
+        public static explicit operator decimal(Real r) => (decimal) r._v;
     }
 }


### PR DESCRIPTION
Real is a type that, in debug mode, acts like a float, and in release mode, acts like a double. A compiler flag can be provided to override this behavior.

I didn't reimplement the Math library, so you'll have to do some casts to and from double if you want to use it. If that gets annoying, implement convenience methods at your discretion.

It builds, but it hasn't been tested yet. My next major project is to get a unit test engine up and going and start writing unit tests in this codebase, probably starting right here.

Extra features compared to `double`:  operator ! is implemented, converting zero (and negative zero) to 1.0, nonzero non-NaN values to 0.0, and NaN remains NaN, which seems like the most appropriate interpretation of unary "!" in floating-point. Many things that are static methods on Double are instance properties on Real. I've added IsNear, IsAbsolutelyNear, and IsRelativelyNear to implement "close enough equality". (With all the warnings about "aaaagh! never compare floating-point values for exact equality! aaaaarrrgh!" that languages and compilers give us, you'd think the language libraries would build this in. Well, I'm writing this one, so I did.

Please review.