### PR TITLE
Avoid a (potentially big) copy in capsule.GenerateIndexList.

### DIFF
--- a/engine/calculus/QuadraticSpline1D.cs
+++ b/engine/calculus/QuadraticSpline1D.cs
@@ -24,7 +24,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
 	///     Class <c>QuadraticSpline1D</c> describes a one-dimensional quadratic spline, which is a piecewise function.
-	///		Each piece is defined by a quadratic function, \f$q(x) = a_0 + a_1 x + a_2 x^2\f$, for which the _parameters
+	///		Each piece is defined by a quadratic function, \f$q(x) = a_0 + a_1 x + a_2 x^2\f$, for which the parameters
 	///		are defined such that the piecewise function is continuous. A spline is defined by a series of points that
 	///		the function must intersect, and the program will automatically generate a curve that passes through these
 	///		points. As opposed to a cubic spline, a quadratic spline is not continuous in its second derivative. It is
@@ -32,7 +32,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class QuadraticSpline1D : RaytraceableFunction1D
 	{
-		private float[] _parameters;
+		private float[] parameters;
 		public SortedPointsList<float> Points { get; }
 		
 		/// <summary>
@@ -70,23 +70,23 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			Points = new SortedPointsList<float>(points);
 			
 			// Calculate the coefficients of the spline:
-			_parameters = new float[points.Count];
+			parameters = new float[points.Count];
 			
 			// Find the first segment parameter, which will be a straight line:
 			{
 				float dx = Points.Key[1] - Points.Key[0];
 				float dy = Points.Value[1] - Points.Value[0];
 				
-				_parameters[0] = dy/dx;
+				parameters[0] = dy/dx;
 			}
 			
-			// Recursively find the other _parameters:
+			// Recursively find the other parameters:
 			for (int i = 1; i < points.Count; i++) 
 			{
 				float dx = Points.Key[i] - Points.Key[i-1];
 				float dy = Points.Value[i] - Points.Value[i-1];
 				
-				_parameters[i] = -_parameters[i-1] + 2.0f*dy/dx;
+				parameters[i] = -parameters[i-1] + 2.0f*dy/dx;
 			}
 			
 		}
@@ -142,7 +142,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			float dx = x2 - x1;
 			float dy = y2 - y1;
 			
-			float a = -_parameters[i]*dx + dy;
+			float a = -parameters[i]*dx + dy;
 			float t = (x-x1)/dx;
 			
 			// Return a different function depending on the derivative level:
@@ -181,7 +181,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		
 		/// <summary>
 		///     Solves the equation \f$(q(x))^2 = b_0 + b_1 x + b_2 x^2 + b_3 x^3 + b_4 x^4\f$, returning all values of
-		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the quadratic spline. The _parameters z0 and c
+		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the quadratic spline. The parameters z0 and c
 		///		can be used to substitute x, such that \f$x = z0 + c t\f$. This is useful for raytracing.
 		/// </summary>
 		public override IEnumerable<float> SolveRaytrace(QuarticFunction surfaceFunction, float z0 = 0.0f, float c = 1.0f)
@@ -199,7 +199,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				Real div = 1.0/dx;
 				Real dy = y2 - y1;
 				
-				Real a = -_parameters[i]*dx + dy;
+				Real a = -parameters[i]*dx + dy;
 				
 				// Write in the form of a0 + a1 z + a2 z^2:
 				Real a0 = -a*x1*x1*div*div - (a + dy)*x1*div + y1;

--- a/engine/calculus/QuadraticSpline1D.cs
+++ b/engine/calculus/QuadraticSpline1D.cs
@@ -24,7 +24,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
 	///     Class <c>QuadraticSpline1D</c> describes a one-dimensional quadratic spline, which is a piecewise function.
-	///		Each piece is defined by a quadratic function, \f$q(x) = a_0 + a_1 x + a_2 x^2\f$, for which the parameters
+	///		Each piece is defined by a quadratic function, \f$q(x) = a_0 + a_1 x + a_2 x^2\f$, for which the _parameters
 	///		are defined such that the piecewise function is continuous. A spline is defined by a series of points that
 	///		the function must intersect, and the program will automatically generate a curve that passes through these
 	///		points. As opposed to a cubic spline, a quadratic spline is not continuous in its second derivative. It is
@@ -32,7 +32,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class QuadraticSpline1D : RaytraceableFunction1D
 	{
-		private float[] parameters;
+		private float[] _parameters;
 		public SortedPointsList<float> Points { get; }
 		
 		/// <summary>
@@ -70,23 +70,23 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			Points = new SortedPointsList<float>(points);
 			
 			// Calculate the coefficients of the spline:
-			parameters = new float[points.Count];
+			_parameters = new float[points.Count];
 			
 			// Find the first segment parameter, which will be a straight line:
 			{
 				float dx = Points.Key[1] - Points.Key[0];
 				float dy = Points.Value[1] - Points.Value[0];
 				
-				parameters[0] = dy/dx;
+				_parameters[0] = dy/dx;
 			}
 			
-			// Recursively find the other parameters:
+			// Recursively find the other _parameters:
 			for (int i = 1; i < points.Count; i++) 
 			{
 				float dx = Points.Key[i] - Points.Key[i-1];
 				float dy = Points.Value[i] - Points.Value[i-1];
 				
-				parameters[i] = -parameters[i-1] + 2.0f*dy/dx;
+				_parameters[i] = -_parameters[i-1] + 2.0f*dy/dx;
 			}
 			
 		}
@@ -142,7 +142,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			float dx = x2 - x1;
 			float dy = y2 - y1;
 			
-			float a = -parameters[i]*dx + dy;
+			float a = -_parameters[i]*dx + dy;
 			float t = (x-x1)/dx;
 			
 			// Return a different function depending on the derivative level:
@@ -181,7 +181,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		
 		/// <summary>
 		///     Solves the equation \f$(q(x))^2 = b_0 + b_1 x + b_2 x^2 + b_3 x^3 + b_4 x^4\f$, returning all values of
-		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the quadratic spline. The parameters z0 and c
+		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the quadratic spline. The _parameters z0 and c
 		///		can be used to substitute x, such that \f$x = z0 + c t\f$. This is useful for raytracing.
 		/// </summary>
 		public override IEnumerable<float> SolveRaytrace(QuarticFunction surfaceFunction, float z0 = 0.0f, float c = 1.0f)
@@ -199,7 +199,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				Real div = 1.0/dx;
 				Real dy = y2 - y1;
 				
-				Real a = -parameters[i]*dx + dy;
+				Real a = -_parameters[i]*dx + dy;
 				
 				// Write in the form of a0 + a1 z + a2 z^2:
 				Real a0 = -a*x1*x1*div*div - (a + dy)*x1*div + y1;

--- a/engine/geometry/Capsule.cs
+++ b/engine/geometry/Capsule.cs
@@ -148,7 +148,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			List<Vertex> startCapList = startCap.GenerateVertexList(resolutionU, resolutionU/4);
 			List<Vertex> endCapList = endCap.GenerateVertexList(resolutionU, resolutionU/4);
 			
-			// Using GetRange(), remove the first and last ring of vertices of the shaft, which overlap with the last
+			// Using a slice, remove the first and last ring of vertices of the shaft, which overlap with the last
 			// rings of the startCap and endCap respectively. Later we will stitch the shaft and end caps together with
 			// triangles between them, during the GenerateIndexList() step.
 			Slice<Vertex> shaftSlice = new Slice<Vertex>(

--- a/engine/geometry/Capsule.cs
+++ b/engine/geometry/Capsule.cs
@@ -151,15 +151,17 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			// Using GetRange(), remove the first and last ring of vertices of the shaft, which overlap with the last
 			// rings of the startCap and endCap respectively. Later we will stitch the shaft and end caps together with
 			// triangles between them, during the GenerateIndexList() step.
-			List<Vertex> shaftList = shaft.GenerateVertexList(resolutionU, resolutionV)
-				.GetRange(resolutionU, Cylinder.CalculateVertexCount(resolutionU, resolutionV) - 2*resolutionU);
+			Slice<Vertex> shaftSlice = new Slice<Vertex>(
+				shaft.GenerateVertexList(resolutionU, resolutionV),
+				resolutionU,
+				Cylinder.CalculateVertexCount(resolutionU, resolutionV) - 2*resolutionU);
 			
 			// Recalculate the surface normal between the cylinder and the start cap:
 			for (int i = 0; i < (resolutionU - 1); i++)
 			{
 				Vector3 surfacePosition = startCapList[(resolutionU/4-1)*resolutionU + i + 1].Position;
 				Vector3 du = surfacePosition - startCapList[(resolutionU/4-1)*resolutionU + i + 1 + 1].Position;
-				Vector3 dv = surfacePosition - shaftList[i].Position;
+				Vector3 dv = surfacePosition - shaftSlice[i].Position;
 				
 				// Calculate the position of the rings of vertices:
 				Vector3 surfaceNormal = Vector3.Cross(Vector3.Normalize(du), Vector3.Normalize(dv));
@@ -170,14 +172,14 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			// Stitch the end of the triangles:
 			Vector3 surfacePosition2 = startCapList[(resolutionU/4-1)*resolutionU + resolutionU].Position;
 			Vector3 du2 = surfacePosition2 - startCapList[(resolutionU/4-1)*resolutionU + 1].Position;
-			Vector3 dv2 = surfacePosition2 - shaftList[resolutionU].Position;
+			Vector3 dv2 = surfacePosition2 - shaftSlice[resolutionU].Position;
 			
 			// Calculate the position of the rings of vertices:
 			Vector3 surfaceNormal2 = Vector3.Cross(Vector3.Normalize(du2), Vector3.Normalize(dv2));
 			
 			startCapList[(resolutionU/4-1)*resolutionU + resolutionU] = new Vertex(surfacePosition2, surfaceNormal2);
 			
-			return startCapList.Concat(shaftList).Concat(endCapList).ToList();
+			return startCapList.Concat(shaftSlice).Concat(endCapList).ToList();
 		}
 		
 		/// <inheritdoc />

--- a/engine/utilities/Slice.cs
+++ b/engine/utilities/Slice.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace FreedomOfFormFoundation.AnatomyEngine
+{
+    // A Slice is a lightweight, shallow view of part of an underlying IList. It can be used to avoid copying.
+    public class Slice<T> : IReadOnlyList<T>
+    {
+        public Slice(IList<T> list, int offset, int count)
+        {
+            Original = list;
+            Offset = offset;
+            Count = count;
+            Debug.Assert(count > 0, "Negative-length slice is illegal");
+            Debug.Assert(offset > 0, "Negative slice offset is illegal");
+            Debug.Assert(offset + count <= list.Count, "Slice too large");
+        }
+
+        public int Count { get; }
+        public int Offset { get; }
+        public IList<T> Original { get; }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return Original.Skip(Offset).Take(Count).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < Count, "Slice index out of range");
+                return Original[index + Offset];
+            }
+        }
+    }
+}

--- a/engine/utilities/Slice.cs
+++ b/engine/utilities/Slice.cs
@@ -1,13 +1,43 @@
-﻿using System.Collections;
+﻿/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ *
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
-    // A Slice is a lightweight, shallow view of part of an underlying IList. It can be used to avoid copying.
-    public struct Slice<T> : IReadOnlyList<T>
+    /// <summary>
+    /// A Slice is a lightweight, shallow view of part of an underlying IList. It can be used to avoid copying.
+    /// </summary>
+    /// <typeparam name="T">Type stored in the underlying IList.</typeparam>
+    public readonly struct Slice<T> : IReadOnlyList<T>
     {
+        /// <summary>
+        /// Construct a Slice viewing a specific list at a specific range.
+        /// </summary>
+        /// <remarks>Slice performs bounds-checking in debug builds, but skips it in release builds. It is intended
+        /// to be used as a higher-performance alternative to GetRange when the original list will not change and
+        /// no copy is explicitly desired.</remarks>
+        /// <param name="list">List to slice.</param>
+        /// <param name="offset">The index of the original list that should correspond to the 0th index of the slice;
+        /// the first index that is in range (if the slice has a length greater than 0).</param>
+        /// <param name="count">The number of items to include in the slice. The last included item of the underlying
+        /// list will be the item at index <c>offset + count - 1</c>.</param>
         public Slice(IList<T> list, int offset, int count)
         {
             Original = list;
@@ -18,25 +48,45 @@ namespace FreedomOfFormFoundation.AnatomyEngine
             Debug.Assert(offset + count <= list.Count, "Slice too large");
         }
 
+        /// <summary>
+        /// Number of items in this slice.
+        /// </summary>
         public int Count { get; }
+
+        /// <summary>
+        /// Location in the original list where this slice starts.
+        /// </summary>
         public int Offset { get; }
+
+        /// <summary>
+        /// The list this slice is viewing into. If the list changes, the slice may become invalid by referring
+        /// to indexes that don't exist.
+        /// </summary>
         public IList<T> Original { get; }
 
+        /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator()
         {
             return Original.Skip(Offset).Take(Count).GetEnumerator();
         }
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Retrieve one element of this slice.
+        /// </summary>
+        /// <remarks>The index is relative to the base of this slice, not the original, underlying list.</remarks>
+        /// <param name="index">Index into the slice to retrieve a value from.</param>
         public T this[int index]
         {
             get
             {
                 Debug.Assert(index < Count, "Slice index out of range");
+                Debug.Assert(index >= 0, "Slice index negative");
                 return Original[index + Offset];
             }
         }

--- a/engine/utilities/Slice.cs
+++ b/engine/utilities/Slice.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
     // A Slice is a lightweight, shallow view of part of an underlying IList. It can be used to avoid copying.
-    public class Slice<T> : IReadOnlyList<T>
+    public struct Slice<T> : IReadOnlyList<T>
     {
         public Slice(IList<T> list, int offset, int count)
         {


### PR DESCRIPTION
capsule.GenerateIndexList copies most of its cylinder's index list (GetRange is a shallow copy) to trim off the end rings that need to belong to the hemisphere endcaps instead. A Slice type, which is an offset view of a backing list, preserves the existing code without copying the list.

I believe the existing call into this function would cause the list being unnecessarily mostly copied to be about 65,000 elements long. Unnecessary copies are fine (and often optimal, for languages that aren't designed around slicing) for small lists but a bad idea for large ones, and the "small" threshhold is somewhere below a thousand.