### PR TITLE
Fix solution file for mono & MonoDevelop

### DIFF
--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\gui\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\gui\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -82,6 +83,9 @@
         <Project>{c05aa306-d502-4117-aad9-b3b702d0feb1}</Project>
         <Name>engine</Name>
       </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+      <None Include="packages.config" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/EngineTests/RealTests.cs
+++ b/EngineTests/RealTests.cs
@@ -14,10 +14,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using Xunit;
-using FreedomOfFormFoundation.AnatomyEngine;
-
 // IDE-specific warning suppression comments go here.
 // ReSharper warns about "obvious equals", when I have the same literal expression on each side of the == operator.
 // That's often useful because it's usually a mistake, but here it's a very deliberate part of testing == itself.
@@ -29,12 +25,15 @@ using FreedomOfFormFoundation.AnatomyEngine;
 // separate assembly so its flags don't apply here.
 #if !REALTYPE_DOUBLE && !REALTYPE_FLOAT && !REALTYPE_DECIMAL
 #if DEBUG
-  #define REALTYPE_FLOAT
+#define REALTYPE_FLOAT
 #else
 #define REALTYPE_DOUBLE
 #endif
 #endif
 
+using System;
+using Xunit;
+using FreedomOfFormFoundation.AnatomyEngine;
 
 namespace EngineTests
 {

--- a/EngineTests/packages.config
+++ b/EngineTests/packages.config
@@ -6,4 +6,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/engine/engine.csproj
+++ b/engine/engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Configurations>Debug;Release;UnitTests;UnitTests Real Float;UnitTests Real Double;UnitTests Real Decimal</Configurations>
+    <Configurations>Debug;ExportDebug;ExportRelease;UnitTests;UnitTests Real Float;UnitTests Real Double;UnitTests Real Decimal</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'UnitTests Real Float' ">

--- a/gui/AnatomyProject.sln
+++ b/gui/AnatomyProject.sln
@@ -27,28 +27,26 @@ Global
 		{67442733-B150-4B9A-9F6C-1DCECDA08CCF}.UnitTests Real Decimal|Any CPU.ActiveCfg = Debug|Any CPU
 		{67442733-B150-4B9A-9F6C-1DCECDA08CCF}.UnitTests Real Double|Any CPU.ActiveCfg = Debug|Any CPU
 		{67442733-B150-4B9A-9F6C-1DCECDA08CCF}.UnitTests Real Float|Any CPU.ActiveCfg = Debug|Any CPU
+		
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.ExportRelease|Any CPU.ActiveCfg = Debug|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests|Any CPU.ActiveCfg = UnitTests|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests|Any CPU.Build.0 = UnitTests|Any CPU
+		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests|Any CPU.ActiveCfg = UnitTests|Any CPU
+		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests|Any CPU.Build.0 = UnitTests|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Float|Any CPU.ActiveCfg = UnitTests Real Float|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Float|Any CPU.Build.0 = UnitTests Real Float|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Double|Any CPU.ActiveCfg = UnitTests Real Double|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Double|Any CPU.Build.0 = UnitTests Real Double|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Decimal|Any CPU.ActiveCfg = UnitTests Real Decimal|Any CPU
 		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests Real Decimal|Any CPU.Build.0 = UnitTests Real Decimal|Any CPU
-		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests|Any CPU.ActiveCfg = UnitTests|Any CPU
-		{C05AA306-D502-4117-AAD9-B3B702D0FEB1}.UnitTests|Any CPU.Build.0 = UnitTests|Any CPU
+		
 		{9D10705A-A834-4049-94B2-CE7501EBAB28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9D10705A-A834-4049-94B2-CE7501EBAB28}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.ExportRelease|Any CPU.ActiveCfg = Debug|Any CPU
-		{9D10705A-A834-4049-94B2-CE7501EBAB28}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
+		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests|Any CPU.ActiveCfg = UnitTests|Any CPU
+		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests|Any CPU.Build.0 = UnitTests|Any CPU
 		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests Real Float|Any CPU.ActiveCfg = UnitTests Real Float|Any CPU
 		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests Real Float|Any CPU.Build.0 = UnitTests Real Float|Any CPU
 		{9D10705A-A834-4049-94B2-CE7501EBAB28}.UnitTests Real Double|Any CPU.ActiveCfg = UnitTests Real Double|Any CPU


### PR DESCRIPTION
The solution file caused MonoDevelop to complain, and there was an issue that prevented compiling the program or the unit tests. This PR allows MonoDevelop to run unit tests as well, and fixes the compiler error.