### PR TITLE
Add Studio Lights to GUI scene

### DIFF
--- a/gui/Main.tscn
+++ b/gui/Main.tscn
@@ -1,26 +1,15 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://ExampleBone.cs" type="Script" id=1]
-[ext_resource path="res://photo_studio_01_1k.hdr" type="Texture" id=2]
+[ext_resource path="res://studiolights/BrightStudio.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Camera.cs" type="Script" id=3]
-
-[sub_resource type="PanoramaSky" id=1]
-panorama = ExtResource( 2 )
-
-[sub_resource type="Environment" id=2]
-background_mode = 2
-background_sky = SubResource( 1 )
 
 [node name="Spatial" type="Spatial"]
 
 [node name="ExampleBone" type="MeshInstance" parent="."]
 script = ExtResource( 1 )
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource( 2 )
-
-[node name="OmniLight" type="OmniLight" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.66016, 3.87789, -0.534762 )
+[node name="StudioLights" parent="." instance=ExtResource( 2 )]
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )

--- a/gui/project.godot
+++ b/gui/project.godot
@@ -10,7 +10,6 @@ config_version=4
 
 _global_script_classes=[  ]
 _global_script_class_icons={
-
 }
 
 [application]
@@ -20,7 +19,6 @@ run/main_scene="res://Main.tscn"
 
 [rendering]
 
-quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 vram_compression/import_etc2=false
 quality/filters/msaa=3

--- a/gui/studiolights/BrightStudio.tscn
+++ b/gui/studiolights/BrightStudio.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="Environment" id=1]
+background_mode = 1
+background_color = Color( 0.227451, 0.227451, 0.227451, 1 )
+
+[node name="BrightStudio" type="WorldEnvironment"]
+environment = SubResource( 1 )
+
+[node name="SpotLight1" type="DirectionalLight" parent="."]
+transform = Transform( -0.521309, -0.0381757, 0.852514, 0.0760213, 0.992949, 0.0909511, -0.849975, 0.112223, -0.514731, 31.1274, 7.45084, -15.5257 )
+light_color = Color( 0.788235, 0.878431, 1, 1 )
+
+[node name="SpotLight2" type="DirectionalLight" parent="."]
+transform = Transform( 0.339098, 0.203035, -0.91858, -0.00145433, 0.976545, 0.21531, 0.94075, -0.0716752, 0.331439, -18.2357, 3.02746, 5.65486 )
+light_color = Color( 0.823529, 0.905882, 1, 1 )
+
+[node name="SpotLight3" type="DirectionalLight" parent="."]
+transform = Transform( 0.016908, 0.486021, -0.873783, -0.103508, 0.870064, 0.481949, 0.994485, 0.0822946, 0.065018, -11.9414, 9.92281, 2.08138 )
+light_color = Color( 0.733333, 0.827451, 0.796078, 1 )
+light_energy = 0.89
+
+[node name="SpotLight4" type="DirectionalLight" parent="."]
+transform = Transform( 0.646922, -0.347692, 0.678677, 0.0243401, 0.898964, 0.437346, -0.762168, -0.26641, 0.590022, 41.6905, 27.316, 24.1203 )
+light_color = Color( 0.901961, 0.917647, 0.964706, 1 )
+light_energy = 0.78
+
+[node name="GroundLight" type="DirectionalLight" parent="."]
+transform = Transform( -0.0463951, 0.99874, -0.0191384, 0.0691234, -0.0159033, -0.997481, -0.996529, -0.0476012, -0.0682985, 2.9591, -32.2353, -6.47292 )
+light_color = Color( 0.317647, 0.34902, 0.364706, 1 )
+light_specular = 0.12


### PR DESCRIPTION
I've added some studio lights to the GUI scene. This makes it easier to view the models as they are generated. In the future, we might choose to support multiple studio light setups for different needs. This patch also fixes the dependency error (due to a missing lighting file) that Godot spits out on startup.

![image](https://user-images.githubusercontent.com/72281292/127875847-5e95ef30-728b-4c6f-a069-23157e6421eb.png)
![image](https://user-images.githubusercontent.com/72281292/127876311-a3ae9f9a-2331-4da5-8884-47f8cfa284aa.png)
