### PR TITLE
Include GlmSharp and refactor float to double throughout Engine

### DIFF
--- a/engine/anatomy/Bone.cs
+++ b/engine/anatomy/Bone.cs
@@ -14,8 +14,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections;
-using System.Numerics;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
@@ -67,7 +67,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy
 		/// </summary>
 		public override Surface GetGeometry()
 		{
-			return new Hemisphere(1.0f, new Vector3(0.0f, 0.0f, 0.0f), new Vector3(0.0f, 1.0f, 0.0f));
+			return new Hemisphere(1.0, new dvec3(0.0, 0.0, 0.0), new dvec3(0.0, 1.0, 0.0));
 		}
 	}
 }

--- a/engine/anatomy/bones/LongBone.cs
+++ b/engine/anatomy/bones/LongBone.cs
@@ -15,8 +15,8 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using FreedomOfFormFoundation.AnatomyEngine.Anatomy;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
@@ -41,7 +41,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones
 		/// <param name="radius">
 		/// 	<inheritdoc cref="LongBone.Radius"/>
 		/// </param>
-		public LongBone(Curve centerCurve, ContinuousMap<Vector2, float> radius)
+		public LongBone(Curve centerCurve, ContinuousMap<dvec2, double> radius)
 		{
 			this.CenterCurve = centerCurve;
 			this.Radius = radius;
@@ -59,8 +59,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones
 		/// <param name="radius">
 		/// 	<inheritdoc cref="LongBone.Radius"/>
 		/// </param>
-		public LongBone(Curve centerCurve, ContinuousMap<float, float> radius)
-			: this(centerCurve, new DomainToVector2<float>(new Vector2(0.0f, 1.0f), radius))
+		public LongBone(Curve centerCurve, ContinuousMap<double, double> radius)
+			: this(centerCurve, new DomainToVector2<double>(new dvec2(0.0, 1.0), radius))
 		{
 			
 		}
@@ -75,8 +75,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones
 		/// <param name="radius">
 		/// 	The constant radius of the <c>Capsule</c> representing the shape of the bone.
 		/// </param>
-		public LongBone(Curve centerCurve, float radius)
-			: this(centerCurve, new ConstantFunction<Vector2, float>(radius))
+		public LongBone(Curve centerCurve, double radius)
+			: this(centerCurve, new ConstantFunction<dvec2, double>(radius))
 		{
 			
 		}
@@ -89,7 +89,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones
 		/// <see cref="FreedomOfFormFoundation.AnatomyEngine.Geometry.Capsule"/> for more information on the
 		/// properties and domain of this height map.
 		/// </summary>
-		public ContinuousMap<Vector2, float> Radius { get; set; }
+		public ContinuousMap<dvec2, double> Radius { get; set; }
 		
 		/// <summary>
 		/// The central curve along the length of the shaft of the long bone around which the <c>Capsule</c> is
@@ -112,7 +112,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones
 		public override Surface GetGeometry()
 		{
 			// Sequentially add the influence of each joint to the bone's radial deformations:
-			ContinuousMap<Vector2, float> deformations = Radius;
+			ContinuousMap<dvec2, double> deformations = Radius;
 			foreach (var i in InteractingJoints)
 			{
 				MoldCastMap boneHeightMap = new MoldCastMap(CenterCurve,

--- a/engine/anatomy/joints/HingeJoint.cs
+++ b/engine/anatomy/joints/HingeJoint.cs
@@ -1,5 +1,19 @@
-using System.Collections;
-using System.Numerics;
+/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ * 
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
@@ -14,12 +28,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Anatomy.Joints
 			articularSurface = new SymmetricCylinder(centerLine, radius);
 		}
 		
-		public HingeJoint(LineSegment centerLine, RaytraceableFunction1D radius, ContinuousMap<float, float> startAngle, ContinuousMap<float, float> endAngle)
+		public HingeJoint(LineSegment centerLine, RaytraceableFunction1D radius, ContinuousMap<double, double> startAngle, ContinuousMap<double, double> endAngle)
 		{
 			articularSurface = new SymmetricCylinder(centerLine, radius, startAngle, endAngle);
 		}
 		
-		//public HingeJoint(LineSegment centerLine, float radius)
+		//public HingeJoint(LineSegment centerLine, double radius)
 		//{
 		//	articularSurface = new SymmetricCylinder(centerLine, radius);
 		//}

--- a/engine/calculus/ConstantFunction.cs
+++ b/engine/calculus/ConstantFunction.cs
@@ -14,10 +14,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
-using System;
-
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
@@ -27,16 +23,16 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class ConstantFunction<TIn, TOut> : ContinuousMap<TIn, TOut>
 	{
-		TOut constant;
+		TOut _constant;
 		
 		public ConstantFunction(TOut constant)
 		{
-			this.constant = constant;
+			_constant = constant;
 		}
 		
 		public override TOut GetValueAt(TIn t)
 		{
-			return constant;
+			return _constant;
 		}
 	}
 }

--- a/engine/calculus/ContinuousMap.cs
+++ b/engine/calculus/ContinuousMap.cs
@@ -14,8 +14,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
 using System;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus

--- a/engine/calculus/CubicFunction.cs
+++ b/engine/calculus/CubicFunction.cs
@@ -16,60 +16,58 @@
 
 using System.Collections.Generic;
 using System.Numerics;
-using System.Linq;
 using System;
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
 	/// A CubicFunction defines a cubic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3\f$.
 	/// </summary>
-	public class CubicFunction : ContinuousMap<float, float>
+	public class CubicFunction : ContinuousMap<double, double>
 	{
-		float a0;
-		float a1;
-		float a2;
-		float a3;
+		double _a0;
+		double _a1;
+		double _a2;
+		double _a3;
 		
 		/// <summary>
 		///     A cubic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3\f$.
 		///		See https://en.wikipedia.org/wiki/Cubic_equation for more information.
 		/// </summary>
-		public CubicFunction(float a0, float a1, float a2, float a3)
+		public CubicFunction(double a0, double a1, double a2, double a3)
 		{
-			this.a0 = a0;
-			this.a1 = a1;
-			this.a2 = a2;
-			this.a3 = a3;
+			_a0 = a0;
+			_a1 = a1;
+			_a2 = a2;
+			_a3 = a3;
 		}
 		
-		public float GetNthDerivativeAt(float x, uint derivative)
+		public double GetNthDerivativeAt(double x, uint derivative)
 		{
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
-				case 0: return a0 + a1*x + a2*x*x + a3*x*x*x;
-				case 1: return a1 + 2.0f*a2*x + 3.0f*a3*x*x;
-				case 2: return 2.0f*a2 + 6.0f*a3*x;
-				case 3: return 6.0f*a3;
-				default: return 0.0f;
+				case 0: return _a0 + _a1*x + _a2*x*x + _a3*x*x*x;
+				case 1: return _a1 + 2.0*_a2*x + 3.0*_a3*x*x;
+				case 2: return 2.0*_a2 + 6.0*_a3*x;
+				case 3: return 6.0*_a3;
+				default: return 0.0;
 			}
 		}
 		
-		public override float GetValueAt(float x)
+		public override double GetValueAt(double x)
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
 		
-		public float GetDerivativeAt(float x)
+		public double GetDerivativeAt(double x)
 		{
 			return GetNthDerivativeAt(x, 1);
 		}
 		
-		public IEnumerable<float> Roots()
+		public IEnumerable<double> Roots()
 		{
-			return CubicFunction.Solve(a0, a1, a2, a3);
+			return Solve(_a0, _a1, _a2, _a3);
 		}
 		
 		/// <summary>
@@ -77,11 +75,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///		\f$x\f$ for which the equation is true. See https://en.wikipedia.org/wiki/Cubic_equation for the
 		///		algorithm used.
 		/// </summary>
-		public static IEnumerable<float> Solve(float d, float c, float b, float a)
+		public static IEnumerable<double> Solve(double d, double c, double b, double a)
 		{
 			if(Math.Abs(a) <= 0.005f)
 			{
-				foreach (float v in QuadraticFunction.Solve(d, c, b))
+				foreach (double v in QuadraticFunction.Solve(d, c, b))
 				{
 					yield return v;
 				}
@@ -110,9 +108,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			
 			foreach (Complex root in roots)
 			{
-				if(Math.Abs(root.Imaginary) <= 0.05f)
+				if(Math.Abs(root.Imaginary) <= 0.05)
 				{
-					yield return (float)root.Real;
+					yield return root.Real;
 				}
 			}
 		}

--- a/engine/calculus/DomainToVector2.cs
+++ b/engine/calculus/DomainToVector2.cs
@@ -14,10 +14,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
-using System;
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -32,10 +29,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// <param name="direction">
 	/// 	The direction in which the 1D function is placed onto the 2D domain.
 	/// </param>
-	public class DomainToVector2<TOut> : ContinuousMap<Vector2, TOut>
+	public class DomainToVector2<TOut> : ContinuousMap<dvec2, TOut>
 	{
-		public Vector2 ParameterDirection { get; set; }
-		public ContinuousMap<float, TOut> Function { get; set; }
+		public dvec2 ParameterDirection { get; set; }
+		public ContinuousMap<double, TOut> Function { get; set; }
 		
 		/// <summary>
 		///		Constructs a ContinuousMap taking 2D input values, based on a ContinuousMap that takes 1D input values.
@@ -56,16 +53,16 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The direction in which the 1D function is placed onto the 2D domain. The magnitude of this vector
 		/// 	has an effect on the scale of the function.
 		/// </param>
-		public DomainToVector2(Vector2 direction, ContinuousMap<float, TOut> function)
+		public DomainToVector2(dvec2 direction, ContinuousMap<double, TOut> function)
 		{
-			this.ParameterDirection = direction;
-			this.Function = function;
+			ParameterDirection = direction;
+			Function = function;
 		}
 		
 		/// <inheritdoc />
-		public override TOut GetValueAt(Vector2 t)
+		public override TOut GetValueAt(dvec2 t)
 		{
-			return Function.GetValueAt(Vector2.Dot(ParameterDirection, t));
+			return Function.GetValueAt(dvec2.Dot(ParameterDirection, t));
 		}
 	}
 }

--- a/engine/calculus/LinearSpline1D.cs
+++ b/engine/calculus/LinearSpline1D.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using System.Linq;
 using System;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
@@ -30,14 +28,14 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class LinearSpline1D : RaytraceableFunction1D
 	{
-		private float[] _parameters;
-		public SortedPointsList<float> Points { get; }
+		private double[] _parameters;
+		public SortedPointsList<double> Points { get; }
 		
 		/// <summary>
 		///     Construct a linear spline using a set of input points.
 		/// 	<example>For example:
 		/// 	<code>
-		/// 		SortedList<float, float> splinePoints = new SortedList<float, float>();
+		/// 		SortedList<double, double> splinePoints = new SortedList<double, double>();
 		/// 		splinePoints.Add(0.0f, 1.1f);
 		/// 		splinePoints.Add(0.3f, 0.4f);
 		/// 		splinePoints.Add(1.0f, 2.0f);
@@ -51,30 +49,30 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	A linear spline must have at least two points to be properly defined. If <c>points</c> contains less than
 		/// 	two points, the spline is undefined, so an <c>ArgumentException</c> is thrown.
 		/// </exception>
-		public LinearSpline1D(SortedList<float, float> points)
+		public LinearSpline1D(SortedList<double, double> points)
 		{
 			if (points.Count < 2)
 			{
 				if (points.Count == 1)
 				{
-					throw new ArgumentException("List contains only a single point. A spline must have at least two points.", "points");
+					throw new ArgumentException("List contains only a single point. A spline must have at least two points.", nameof(points));
 				}
 				else
 				{
-					throw new ArgumentException("List is empty. A spline must have at least two points.", "points");
+					throw new ArgumentException("List is empty. A spline must have at least two points.", nameof(points));
 				}
 			}
 			
-			Points = new SortedPointsList<float>(points);
+			Points = new SortedPointsList<double>(points);
 
 			// Calculate the coefficients for each segment of the spline:
-			_parameters = new float[points.Count];
+			_parameters = new double[points.Count];
 
 			// Recursively find the _parameters:
 			for (int i = 1; i < points.Count; i++)
 			{
-				float dx = Points.Key[i] - Points.Key[i - 1];
-				float dy = Points.Value[i] - Points.Value[i - 1];
+				double dx = Points.Key[i] - Points.Key[i - 1];
+				double dy = Points.Value[i] - Points.Value[i - 1];
 
 				_parameters[i] = dy / dx;
 			}
@@ -96,12 +94,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If 
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public float GetNthDerivativeAt(float x, uint derivative)
+		public double GetNthDerivativeAt(double x, uint derivative)
 		{
 			// The input parameter must lie between the outer points, and must not be NaN:
 			if (!( x >= Points.Key[0] && x <= Points.Key[Points.Count - 1]))
 			{
-				throw new ArgumentOutOfRangeException("x","Cannot interpolate outside the interval given by the spline points.");
+				throw new ArgumentOutOfRangeException(nameof(x), "Cannot interpolate outside the interval given by the spline points.");
 			}
 			
 			// Find the index `i` of the closest point to the right of the input `x` parameter, which is the right point
@@ -122,28 +120,28 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				i++;
 			}
 
-			float x1 = Points.Key[i-1];
-			float x2 = Points.Key[i];
-			float y1 = Points.Value[i-1];
-			float y2 = Points.Value[i];
+			double x1 = Points.Key[i-1];
+			double x2 = Points.Key[i];
+			double y1 = Points.Value[i-1];
+			double y2 = Points.Value[i];
 			
 			// Calculate and return the interpolated value:
-			float dx = x2 - x1;
-			float dy = y2 - y1;
+			double dx = x2 - x1;
+			double dy = y2 - y1;
 
-			float slope = dy / dx;
+			double slope = dy / dx;
 
-			float local_x = x - x1;
+			double local_x = x - x1;
 
-			float local_y = local_x * slope;
-			float global_y = local_y + y1;
+			double local_y = local_x * slope;
+			double global_y = local_y + y1;
 
 			// Return the result of evaluating a derivative function, depending on the derivative level:
 			switch (derivative)
 			{
 				case 0: return global_y;
 				case 1: return slope;
-				default: return 0.0f;
+				default: return 0.0;
 			}
 		}
 
@@ -154,7 +152,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public override float GetValueAt(float x)
+		public override double GetValueAt(double x)
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
@@ -166,7 +164,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public float GetDerivativeAt(float x)
+		public double GetDerivativeAt(double x)
 		{
 			return GetNthDerivativeAt(x, 1);
 		}
@@ -176,7 +174,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the linear spline. The _parameters z0 and c
 		///		can be used to substitute x, such that \f$x = z0 + c t\f$. This is useful for raytracing.
 		/// </summary>
-		public override IEnumerable<float> SolveRaytrace(QuarticFunction surfaceFunction, float z0 = 0.0f, float c = 1.0f)
+		public override IEnumerable<double> SolveRaytrace(QuarticFunction surfaceFunction, double z0 = 0.0, double c = 1.0)
 		{
 			throw new NotImplementedException();
 			return null;

--- a/engine/calculus/MoldCastMap.cs
+++ b/engine/calculus/MoldCastMap.cs
@@ -14,9 +14,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
 using System;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
@@ -34,7 +34,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// 	A MoldCastMap projects one surface onto a mold surface, giving the distance between the two surfaces
 	///		on each coordinate point. This map can for example be used to shape the Cylinder and the Capsule surfaces.
 	/// </summary>
-	public class MoldCastMap : ContinuousMap<Vector2, float>
+	public class MoldCastMap : ContinuousMap<dvec2, double>
 	{
 		/// <summary>
 		/// 	The surface from which the rays are cast. A ray is cast out of each point on the surface in the
@@ -52,7 +52,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	has missed the mold surface and shoots off to infinity. When that happens, return the length of
 		/// 	defaultRadius instead, so that the heightmap is still defined.
 		/// </summary>
-		private readonly ContinuousMap<Vector2, float> defaultRadius;
+		private readonly ContinuousMap<dvec2, double> defaultRadius;
 		
 		/// <summary>
 		/// 	The direction along the normal of the raycastSurface from which to cast each ray. This could either be
@@ -63,7 +63,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <summary>
 		/// 	The maximum ray length before a ray is considered to be out of bounds.
 		/// </summary>
-		private readonly float maxDistance;
+		private readonly double maxDistance;
 		
 		/// <summary>
 		/// 	Construct a new MoldCastMap from a curve.
@@ -91,10 +91,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </param>
 		public MoldCastMap(Curve raycastCurve,
 								IRaytraceableSurface moldSurface,
-								ContinuousMap<Vector2, float> defaultRadius,
+								ContinuousMap<dvec2, double> defaultRadius,
 								RayCastDirection direction = RayCastDirection.Outwards,
-								float maxDistance = Single.PositiveInfinity)
-			: this(new Capsule(raycastCurve, 0.0f), moldSurface, defaultRadius, direction, maxDistance)
+								double maxDistance = Double.PositiveInfinity)
+			: this(new Capsule(raycastCurve, 0.0), moldSurface, defaultRadius, direction, maxDistance)
 		{
 			
 		}
@@ -124,9 +124,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </param>
 		public MoldCastMap(Surface raycastSurface,
 								IRaytraceableSurface moldSurface,
-								ContinuousMap<Vector2, float> defaultRadius,
+								ContinuousMap<dvec2, double> defaultRadius,
 								RayCastDirection direction = RayCastDirection.Outwards,
-								float maxDistance = Single.PositiveInfinity)
+								double maxDistance = Double.PositiveInfinity)
 		{
 			this.raycastSurface = raycastSurface;
 			this.moldSurface = moldSurface;
@@ -136,12 +136,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		}
 		
 		/// <inheritdoc />
-		public override float GetValueAt(Vector2 uv)
+		public override double GetValueAt(dvec2 uv)
 		{
-			float directionSign = (direction == RayCastDirection.Outwards) ? 1.0f : -1.0f;
-			
-			Ray ray = new Ray(raycastSurface.GetPositionAt(uv), directionSign*Vector3.Normalize(raycastSurface.GetNormalAt(uv)));
-			float intersectionRadius = moldSurface.RayIntersect(ray);
+			double directionSign = (direction == RayCastDirection.Outwards) ? 1.0 : -1.0;
+
+			Ray ray = new Ray(raycastSurface.GetPositionAt(uv), directionSign*raycastSurface.GetNormalAt(uv).Normalized);
+			double intersectionRadius = moldSurface.RayIntersect(ray);
 			
 			if (Math.Abs(intersectionRadius) <= maxDistance)
 			{

--- a/engine/calculus/MutableCubicSpline1D.cs
+++ b/engine/calculus/MutableCubicSpline1D.cs
@@ -17,13 +17,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
-    /// <summary>
-    /// MutableCubicSpline1D uses MutablePiecewiseInterpolatedCurve to implement moveable point behavior for CubicSpline1D.
-    /// </summary>
     public class MutableCubicSpline1D : MutablePiecewiseInterpolatedCurve<MutablePair, double>
     {
         /// <summary>
@@ -41,19 +37,19 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
             return mp;
         }
 
-        /// <summary>
-        /// Algorithm for converting a sequence of MutablePair instances at one point in time into an immutable
-        /// CubicSpline1D. Because CubicSpline1D operates on `float`, but this type declares double (because we're
-        /// planning to migrate), we introduce CubicSpline1DAdapter to marshal in and out of double.
-        /// </summary>
-        private struct CubicSpline1DFactory : ICurveFactory<MutablePair, double>
+		/// <summary>
+		/// Algorithm for converting a sequence of MutablePair instances at one point in time into an immutable
+		/// CubicSpline1D. Because CubicSpline1D operates on `float`, but this type declares double (because we're
+		/// planning to migrate), we introduce CubicSpline1DAdapter to marshal in and out of double.
+		/// </summary>
+		private struct CubicSpline1DFactory : ICurveFactory<MutablePair, double>
         {
             public ICurve<double> NewCurve(IEnumerable<MutablePair> parameters)
             {
-                SortedList<float, float> sortedPoints = new SortedList<float, float>();
+                SortedList<double, double> sortedPoints = new SortedList<double, double>();
                 foreach (var point in parameters.OrderBy(point => point.Location))
                 {
-                    sortedPoints.Add((float)point.Location, (float)point.Value);
+                    sortedPoints.Add((double)point.Location, (double)point.Value);
                 }
 
                 CubicSpline1D spline = new CubicSpline1D(sortedPoints);
@@ -61,12 +57,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
             }
         }
 
-        /// <summary>
-        /// ICurve{double} view of CubicSpline1D, which doesn't exactly match the ICurve interface and - if it did -
-        /// would be an ICurve{Float} anyway. This wrapper implements the interface by calling the equivalent functions
-        /// on the underlying CubicSpline1D, marshalling between double and float as required.
-        /// </summary>
-        private struct CubicSpline1DAdapter : ICurve<double>
+		/// <summary>
+		/// ICurve{double} view of CubicSpline1D, which doesn't exactly match the ICurve interface and - if it did -
+		/// would be an ICurve{Float} anyway. This wrapper implements the interface by calling the equivalent functions
+		/// on the underlying CubicSpline1D, marshalling between double and float as required.
+		/// </summary>
+		private struct CubicSpline1DAdapter : ICurve<double>
         {
             private CubicSpline1D _spline;
 
@@ -80,11 +76,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
                 _spline = spline;
             }
 
-
-            public double GetValueAt(double x) => _spline.GetValueAt((float)x);
+			public double GetValueAt(double x) => _spline.GetValueAt((float)x);
 
             public double GetDerivativeAt(double x, uint derivative) =>
                 _spline.GetNthDerivativeAt((float)x, derivative);
-        }
-    }
+		}
+	}
 }

--- a/engine/calculus/QuadraticFunction.cs
+++ b/engine/calculus/QuadraticFunction.cs
@@ -15,51 +15,48 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using System.Linq;
 using System;
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
 	///     Class <c>QuadraticFunction</c> describes a quadratic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2\f$.
 	/// </summary>
-	public class QuadraticFunction : ContinuousMap<float, float>
+	public class QuadraticFunction : ContinuousMap<double, double>
 	{
-		float a0;
-		float a1;
-		float a2;
+		private readonly double _a0;
+		private readonly double _a1;
+		private readonly double _a2;
 		
 		/// <summary>
 		///     A quadratic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2\f$.
 		/// </summary>
-		public QuadraticFunction(float a0, float a1, float a2)
+		public QuadraticFunction(double a0, double a1, double a2)
 		{
-			this.a0 = a0;
-			this.a1 = a1;
-			this.a2 = a2;
+			_a0 = a0;
+			_a1 = a1;
+			_a2 = a2;
 		}
 		
-		public float GetNthDerivativeAt(float x, uint derivative)
+		public double GetNthDerivativeAt(double x, uint derivative)
 		{
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
-				case 0: return a0 + a1*x + a2*x*x;
-				case 1: return a1 + 2.0f*a2*x;
-				case 2: return 2.0f*a2;
+				case 0: return _a0 + _a1*x + _a2*x*x;
+				case 1: return _a1 + 2.0f*_a2*x;
+				case 2: return 2.0f*_a2;
 				default: return 0.0f;
 			}
 		}
 		
 		/// <inheritdoc />
-		public override float GetValueAt(float x)
+		public override double GetValueAt(double x)
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
 		
-		public float GetDerivativeAt(float x)
+		public double GetDerivativeAt(double x)
 		{
 			return GetNthDerivativeAt(x, 1);
 		}
@@ -69,20 +66,20 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///		\f$x\f$ for which the equation is true using the 'abc-formula' using the parameters
 		/// 	in this instance of QuadraticFunction.
 		/// </summary>
-		public IEnumerable<float> Roots()
+		public IEnumerable<double> Roots()
 		{
-			return QuadraticFunction.Solve(a0, a1, a2);
+			return Solve(_a0, _a1, _a2);
 		}
 		
 		/// <summary>
 		///     Solves a general equation \f$a_0 + a_1 x + a_2 x^2 = 0\f$, returning all real values of
 		///		\f$x\f$ for which the equation is true using the 'abc-formula'.
 		/// </summary>
-		public static IEnumerable<float> Solve(float a0, float a1, float a2)
+		public static IEnumerable<double> Solve(double a0, double a1, double a2)
 		{
-			if(Math.Abs(a2) <= 0.005f)
+			if(Math.Abs(a2) <= 0.005)
 			{
-				if(Math.Abs(a1) <= 0.005f)
+				if(Math.Abs(a1) <= 0.005)
 				{
 					// There are no roots found:
 					yield break;
@@ -93,16 +90,16 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				}
 				yield break;
 			}
+
+			double x1 = 0.5*(-a1 + Math.Sqrt(a1*a1 - 4.0*a0*a2))/a2;
+			double x2 = 0.5*(-a1 - Math.Sqrt(a1*a1 - 4.0*a0*a2))/a2;
 			
-			float x1 = 0.5f*(-a1 + (float)Math.Sqrt(a1*a1 - 4.0f*a0*a2))/a2;
-			float x2 = 0.5f*(-a1 - (float)Math.Sqrt(a1*a1 - 4.0f*a0*a2))/a2;
-			
-			if(Single.IsNaN(x1) == false)
+			if(Double.IsNaN(x1) == false)
 			{
 				yield return x1;
 			}
-			
-			if(Single.IsNaN(x2) == false)
+
+			if(Double.IsNaN(x2) == false)
 			{
 				yield return x2;
 			}

--- a/engine/calculus/QuadraticSpline1D.cs
+++ b/engine/calculus/QuadraticSpline1D.cs
@@ -15,10 +15,7 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using System.Linq;
 using System;
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -32,14 +29,14 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class QuadraticSpline1D : RaytraceableFunction1D
 	{
-		private float[] _parameters;
-		public SortedPointsList<float> Points { get; }
-		
+		private double[] _parameters;
+		public SortedPointsList<double> Points { get; }
+
 		/// <summary>
 		///     Construct a quadratic spline using a set of input points.
 		/// 	<example>For example:
 		/// 	<code>
-		/// 		SortedList<float, float> splinePoints = new SortedList<float, float>();
+		/// 		SortedList<double, double> splinePoints = new SortedList<double, double>();
 		/// 		splinePoints.Add(0.0f, 1.1f);
 		/// 		splinePoints.Add(0.3f, 0.4f);
 		/// 		splinePoints.Add(1.0f, 2.0f);
@@ -53,29 +50,29 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	A spline must have at least two points to be properly defined. If <c>points</c> contains less than two
 		/// 	points, the spline is undefined, so an <c>ArgumentException</c> is thrown.
 		/// </exception>
-		public QuadraticSpline1D(SortedList<float, float> points)
+		public QuadraticSpline1D(SortedList<double, double> points)
 		{
 			if (points.Count < 2)
 			{
 				if (points.Count == 1)
 				{
-					throw new ArgumentException("points","List contains only a single point. A spline must have at least two points.");
+					throw new ArgumentException("List contains only a single point. A spline must have at least two points.", nameof(points));
 				}
 				else
 				{
-					throw new ArgumentException("points","List is empty. A spline must have at least two points.");
+					throw new ArgumentException("List is empty. A spline must have at least two points.", nameof(points));
 				}
 			}
 			
-			Points = new SortedPointsList<float>(points);
+			Points = new SortedPointsList<double>(points);
 			
 			// Calculate the coefficients of the spline:
-			_parameters = new float[points.Count];
+			_parameters = new double[points.Count];
 			
 			// Find the first segment parameter, which will be a straight line:
 			{
-				float dx = Points.Key[1] - Points.Key[0];
-				float dy = Points.Value[1] - Points.Value[0];
+				double dx = Points.Key[1] - Points.Key[0];
+				double dy = Points.Value[1] - Points.Value[0];
 				
 				_parameters[0] = dy/dx;
 			}
@@ -83,8 +80,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			// Recursively find the other _parameters:
 			for (int i = 1; i < points.Count; i++) 
 			{
-				float dx = Points.Key[i] - Points.Key[i-1];
-				float dy = Points.Value[i] - Points.Value[i-1];
+				double dx = Points.Key[i] - Points.Key[i-1];
+				double dy = Points.Value[i] - Points.Value[i-1];
 				
 				_parameters[i] = -_parameters[i-1] + 2.0f*dy/dx;
 			}
@@ -107,12 +104,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If 
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public float GetNthDerivativeAt(float x, uint derivative)
+		public double GetNthDerivativeAt(double x, uint derivative)
 		{
 			// The input parameter must lie between the outer points, and must not be NaN:
 			if (!( x >= Points.Key[0] && x <= Points.Key[Points.Count - 1]))
 			{
-				throw new ArgumentOutOfRangeException("x","Cannot interpolate outside the interval given by the spline points.");
+				throw new ArgumentOutOfRangeException(nameof(x), "Cannot interpolate outside the interval given by the spline points.");
 			}
 			
 			// Find the index `i` of the closest point to the right of the input `x` parameter, which is the right point
@@ -133,25 +130,25 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				i++;
 			}
 
-			float x1 = Points.Key[i-1];
-			float x2 = Points.Key[i];
-			float y1 = Points.Value[i-1];
-			float y2 = Points.Value[i];
-			
+			double x1 = Points.Key[i-1];
+			double x2 = Points.Key[i];
+			double y1 = Points.Value[i-1];
+			double y2 = Points.Value[i];
+
 			// Calculate and return the interpolated value:
-			float dx = x2 - x1;
-			float dy = y2 - y1;
-			
-			float a = -_parameters[i]*dx + dy;
-			float t = (x-x1)/dx;
-			
+			double dx = x2 - x1;
+			double dy = y2 - y1;
+
+			double a = -_parameters[i]*dx + dy;
+			double t = (x-x1)/dx;
+
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
-				case 0: return (1.0f - t)*y1 + t*y2 + t*(1.0f-t)*a;
-				case 1: return (dy + a * (1.0f - 2.0f * t))/dx;
-				case 2: return (2.0f * a * t)/(dx*dx);
-				default: return 0.0f;
+				case 0: return (1.0 - t)*y1 + t*y2 + t*(1.0-t)*a;
+				case 1: return (dy + a * (1.0 - 2.0 * t))/dx;
+				case 2: return (2.0 * a * t)/(dx*dx);
+				default: return 0.0;
 			}
 		}
 		
@@ -162,7 +159,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If 
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public override float GetValueAt(float x)
+		public override double GetValueAt(double x)
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
@@ -174,7 +171,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The value that is sampled must lie between the outermost points on which the spline is defined. If 
 		/// 	<c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
-		public float GetDerivativeAt(float x)
+		public double GetDerivativeAt(float x)
 		{
 			return GetNthDerivativeAt(x, 1);
 		}
@@ -184,7 +181,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///		\f$x\f$ for which the equation is true. \f$q(x)\f$ is the quadratic spline. The _parameters z0 and c
 		///		can be used to substitute x, such that \f$x = z0 + c t\f$. This is useful for raytracing.
 		/// </summary>
-		public override IEnumerable<float> SolveRaytrace(QuarticFunction surfaceFunction, float z0 = 0.0f, float c = 1.0f)
+		public override IEnumerable<double> SolveRaytrace(QuarticFunction surfaceFunction, double z0 = 0.0, double c = 1.0)
 		{
 			// Solve the polynomial equation for each segment:
 			for (int i = 1; i < Points.Count; i++)
@@ -193,33 +190,33 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				double x2 = Points.Key[i];
 				double y1 = Points.Value[i-1];
 				double y2 = Points.Value[i];
-				
+
 				// Calculate and return the interpolated value:
 				double dx = x2 - x1;
 				double div = 1.0/dx;
 				double dy = y2 - y1;
-				
+
 				double a = -_parameters[i]*dx + dy;
-				
+
 				// Write in the form of a0 + a1 z + a2 z^2:
 				double a0 = -a*x1*x1*div*div - (a + dy)*x1*div + y1;
 				double a1 = 2.0*a*x1*div*div + (a + dy)*div;
 				double a2 = -a*div*div;
-				
+
 				// Substitute z = z0 + c t:
 				double A0 = a0 + a1*z0 + a2*z0*z0;
 				double A1 = (a1 + 2.0*a2*z0)*c;
 				double A2 = a2*c*c;
-				
+
 				// Find the quartic polynomial to solve:
 				double p0 = surfaceFunction.a0 - A0*A0;
 				double p1 = surfaceFunction.a1 - 2.0*A0*A1;
 				double p2 = surfaceFunction.a2 - (2.0*A0*A2 + A1*A1);
 				double p3 = surfaceFunction.a3 - 2.0*A1*A2;
 				double p4 = surfaceFunction.a4 - A2*A2;
-				
+
 				// Solve the quartic polynomial:
-				IEnumerable<float> intersections = QuarticFunction.Solve((float)p0, (float)p1, (float)p2, (float)p3, (float)p4);
+				IEnumerable<double> intersections = QuarticFunction.Solve(p0, p1, p2, p3, p4);
 				
 				// Only return the value if it is sampled within the segment that we are currently considering,
 				// otherwise the value we got is invalid:

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -16,10 +16,7 @@
 
 using System.Collections.Generic;
 using System.Numerics;
-using System.Linq;
 using System;
-using System.Runtime.CompilerServices;
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -28,19 +25,19 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3 + a_4 x^4\f$. See https://en.wikipedia.org/wiki/Quartic_function
 	///	for more information.
 	/// </summary>
-	public class QuarticFunction : ContinuousMap<float, float>
+	public class QuarticFunction : ContinuousMap<double, double>
 	{
-		public float a0 { get; }
-		public float a1 { get; }
-		public float a2 { get; }
-		public float a3 { get; }
-		public float a4 { get; }
+		public double a0 { get; }
+		public double a1 { get; }
+		public double a2 { get; }
+		public double a3 { get; }
+		public double a4 { get; }
 		
 		/// <summary>
 		///     A quartic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3 + a_4 x^4\f$.
 		///		See https://en.wikipedia.org/wiki/Quartic_function for more information.
 		/// </summary>
-		public QuarticFunction(float a0, float a1, float a2, float a3, float a4)
+		public QuarticFunction(double a0, double a1, double a2, double a3, double a4)
 		{
 			this.a0 = a0;
 			this.a1 = a1;
@@ -49,32 +46,32 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			this.a4 = a4;
 		}
 		
-		public float GetNthDerivativeAt(float x, uint derivative)
+		public double GetNthDerivativeAt(double x, uint derivative)
 		{
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
 				case 0: return a0 + a1*x + a2*x*x + a3*x*x*x + a4*x*x*x*x;
-				case 1: return a1 + 2.0f*a2*x + 3.0f*a3*x*x + 4.0f*a4*x*x*x;
-				case 2: return 2.0f*a2 + 6.0f*a3*x + 12.0f*a4*x*x;
-				case 3: return 6.0f*a3 + 24.0f*a4*x;
-				case 4: return 24.0f*a4;
-				default: return 0.0f;
+				case 1: return a1 + 2.0*a2*x + 3.0*a3*x*x + 4.0*a4*x*x*x;
+				case 2: return 2.0*a2 + 6.0*a3*x + 12.0*a4*x*x;
+				case 3: return 6.0*a3 + 24.0*a4*x;
+				case 4: return 24.0*a4;
+				default: return 0.0;
 			}
 		}
 		
 		/// <inheritdoc />
-		public override float GetValueAt(float x)
+		public override double GetValueAt(double x)
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
 		
-		public float GetDerivativeAt(float x)
+		public double GetDerivativeAt(double x)
 		{
 			return GetNthDerivativeAt(x, 1);
 		}
 		
-		public IEnumerable<float> Roots()
+		public IEnumerable<double> Roots()
 		{
 			return QuarticFunction.Solve(a0, a1, a2, a3, a4);
 		}
@@ -84,11 +81,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///		\f$x\f$ for which the equation is true. See https://en.wikipedia.org/wiki/Quartic_function for the
 		///		algorithm used.
 		/// </summary>
-		public static IEnumerable<float> Solve(float e2, float d2, float c2, float b2, float a2)
+		public static IEnumerable<double> Solve(double e2, double d2, double c2, double b2, double a2)
 		{
-			if(Math.Abs(a2) <= 0.005f)
+			if(Math.Abs(a2) <= 0.005)
 			{
-				foreach (float v in CubicFunction.Solve(e2, d2, c2, b2))
+				foreach (double v in CubicFunction.Solve(e2, d2, c2, b2))
 				{
 					yield return v;
 				}
@@ -132,9 +129,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			
 			foreach (Complex root in roots)
 			{
-				if(Math.Abs(root.Imaginary) <= 0.005f)
+				if(Math.Abs(root.Imaginary) <= 0.005)
 				{
-					yield return (float)root.Real;
+					yield return root.Real;
 				}
 			}
 		}

--- a/engine/calculus/RaytraceableFunction1D.cs
+++ b/engine/calculus/RaytraceableFunction1D.cs
@@ -15,18 +15,16 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using System;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
-	public abstract class RaytraceableFunction1D : ContinuousMap<float, float>
+	public abstract class RaytraceableFunction1D : ContinuousMap<double, double>
 	{
 		/// <summary>
 		/// Solves the equation \f$(q(x))^2 = b_0 + b_1 x + b_2 x^2 + b_3 x^3 + b_4 x^4\f$, returning all values of
 		///	\f$x\f$ for which the equation is true. \f$q(x)\f$ is the continuous map. The parameters z0 and c
 		///	can be used to substitute x, such that \f$x = z0 + c t\f$. This is useful for raytracing.
 		/// </summary>
-		public abstract IEnumerable<float> SolveRaytrace(QuarticFunction surfaceFunction, float z0 = 0.0f, float c = 1.0f);
+		public abstract IEnumerable<double> SolveRaytrace(QuarticFunction surfaceFunction, double z0 = 0.0, double c = 1.0);
 	}
 }

--- a/engine/calculus/ShiftedMap2D.cs
+++ b/engine/calculus/ShiftedMap2D.cs
@@ -14,34 +14,33 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Numerics;
-using System;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
 	/// 	<c>ShiftedMap2D<TOut></c> shifts the domain of a 2D map such that the values are taken at
-	/// 	`Shift + Vector2.Multiply(Stretch, uv)`.
+	/// 	`Shift + dvec2.Multiply(Stretch, uv)`.
 	/// </summary>
-	public class ShiftedMap2D<TOut> : ContinuousMap<Vector2, TOut>
+	public class ShiftedMap2D<TOut> : ContinuousMap<dvec2, TOut>
 	{
 		/// <summary>
 		/// 	The vector by which the 2D map is shifted.
 		/// </summary>
-		public Vector2 Shift { get; set; }
+		public dvec2 Shift { get; set; }
 		
 		/// <summary>
 		/// 	The vector by which the 2D map's coordinates are multiplied.
 		/// </summary>
-		public Vector2 Stretch { get; set; }
+		public dvec2 Stretch { get; set; }
 		
 		/// <summary>
 		/// 	The ContinuousMap that is shifted and stretched.
 		/// </summary>
-		public ContinuousMap<Vector2, TOut> Function { get; set; }
+		public ContinuousMap<dvec2, TOut> Function { get; set; }
 		
 		/// <summary>
-		///		Constructs a ShiftedMap2D whose input is shifted by a Vector2.
+		///		Constructs a ShiftedMap2D whose input is shifted by a dvec2.
 		/// </summary>
 		/// <param name="shift">
 		/// 	The vector by which the 2D map is shifted.
@@ -49,14 +48,14 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <param name="function">
 		/// 	The ContinuousMap that is shifted and stretched.
 		/// </param>
-		public ShiftedMap2D(Vector2 shift, ContinuousMap<Vector2, TOut> function)
-			: this(shift, new Vector2(1.0f, 1.0f), function)
+		public ShiftedMap2D(dvec2 shift, ContinuousMap<dvec2, TOut> function)
+			: this(shift, new dvec2(1.0, 1.0), function)
 		{
 			
 		}
 		
 		/// <summary>
-		///		Constructs a ShiftedMap2D whose input is shifted by a Vector2 and stretched by another Vector2.
+		///		Constructs a ShiftedMap2D whose input is shifted by a dvec2 and stretched by another dvec2.
 		/// </summary>
 		/// <param name="shift">
 		/// 	The vector by which the 2D map is shifted.
@@ -67,7 +66,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <param name="function">
 		/// 	The ContinuousMap that is shifted and stretched.
 		/// </param>
-		public ShiftedMap2D(Vector2 shift, Vector2 stretch, ContinuousMap<Vector2, TOut> function)
+		public ShiftedMap2D(dvec2 shift, dvec2 stretch, ContinuousMap<dvec2, TOut> function)
 		{
 			this.Shift = shift;
 			this.Stretch = stretch;
@@ -75,9 +74,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		}
 		
 		/// <inheritdoc />
-		public override TOut GetValueAt(Vector2 uv)
+		public override TOut GetValueAt(dvec2 uv)
 		{
-			return Function.GetValueAt(Shift + Vector2.Multiply(Stretch, uv));
+			return Function.GetValueAt(Shift + Stretch * uv);
 		}
 	}
 }

--- a/engine/calculus/SortedPointsList.cs
+++ b/engine/calculus/SortedPointsList.cs
@@ -15,7 +15,6 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
 using System.Linq;
 using System;
 

--- a/engine/engine.csproj
+++ b/engine/engine.csproj
@@ -4,4 +4,7 @@
     <Configurations>Debug;ExportDebug;ExportRelease;UnitTests</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="GlmSharp" Version="0.9.8" />
+  </ItemGroup>
 </Project>

--- a/engine/geometry/Capsule.cs
+++ b/engine/geometry/Capsule.cs
@@ -15,9 +15,10 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
 using System.Linq;
 using System;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -56,28 +57,28 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	is therefore a two-dimensional function $h(u, \phi)$ that outputs a distance from the curve at each of
 		/// 	the surface's parametric coordinates.
 		/// </param>
-		public Capsule(Curve centerCurve, ContinuousMap<Vector2, float> heightMap)
+		public Capsule(Curve centerCurve, ContinuousMap<dvec2, double> heightMap)
 		{
-			Vector3 startTangent = -centerCurve.GetTangentAt(0.0f);
-			Vector3 startNormal = centerCurve.GetNormalAt(0.0f);
+			dvec3 startTangent = -centerCurve.GetTangentAt(0.0);
+			dvec3 startNormal = centerCurve.GetNormalAt(0.0);
 			
-			Vector3 endTangent = centerCurve.GetTangentAt(1.0f);
-			Vector3 endNormal = centerCurve.GetNormalAt(1.0f);
+			dvec3 endTangent = centerCurve.GetTangentAt(1.0);
+			dvec3 endNormal = centerCurve.GetNormalAt(1.0);
 			
 			this.shaft = new Cylinder(centerCurve, heightMap);
 			this.startCap = new Hemisphere(
-									new ShiftedMap2D<float>(new Vector2(0.0f, -0.5f * (float)Math.PI), heightMap),
+									new ShiftedMap2D<double>(new dvec2(0.0, -0.5 * Math.PI), heightMap),
 									centerCurve.GetStartPosition(),
 									startTangent,
 									startNormal,
-									-Vector3.Cross(startTangent, startNormal)
+									-dvec3.Cross(startTangent, startNormal)
 								);
 			this.endCap = new Hemisphere(
-									new ShiftedMap2D<float>(new Vector2(0.0f, 1.0f + 0.5f * (float)Math.PI), new Vector2(1.0f, -1.0f), heightMap),
+									new ShiftedMap2D<double>(new dvec2(0.0, 1.0 + 0.5 * Math.PI), new dvec2(1.0, -1.0), heightMap),
 									centerCurve.GetEndPosition(),
 									endTangent,
 									endNormal,
-									-Vector3.Cross(endTangent, endNormal)
+									-dvec3.Cross(endTangent, endNormal)
 								);
 		}
 #endregion Constructors
@@ -94,22 +95,22 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		
 #region Base Class Method Overrides
 		/// <inheritdoc />
-		public override Vector3 GetNormalAt(Vector2 uv)
+		public override dvec3 GetNormalAt(dvec2 uv)
 		{
-			float u = uv.X;
-			float v = uv.Y;
-			
-			if ((v >= -0.5f * (float)Math.PI) && (v < 0.0f))
+			double u = uv.x;
+			double v = uv.y;
+
+			if ((v >= -0.5 * Math.PI) && (v < 0.0))
 			{
-				return startCap.GetNormalAt(new Vector2(u, v + 0.5f * (float)Math.PI));
+				return startCap.GetNormalAt(new dvec2(u, v + 0.5 * Math.PI));
 			}
-			else if ((v >= 0.0f) && (v < 1.0f))
+			else if ((v >= 0.0) && (v < 1.0))
 			{
-				return shaft.GetNormalAt(new Vector2(u, v));
+				return shaft.GetNormalAt(new dvec2(u, v));
 			}
-			else if ((v >= 1.0f) && (v <= 1.0f + 0.5f * (float)Math.PI))
+			else if ((v >= 1.0) && (v <= 1.0 + 0.5 * Math.PI))
 			{
-				return endCap.GetNormalAt(new Vector2(u, 1.0f + 0.5f * (float)Math.PI - v));
+				return endCap.GetNormalAt(new dvec2(u, 1.0 + 0.5 * Math.PI - v));
 			}
 			else
 			{
@@ -118,22 +119,22 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetPositionAt(Vector2 uv)
+		public override dvec3 GetPositionAt(dvec2 uv)
 		{
-			float u = uv.X;
-			float v = uv.Y;
+			double u = uv.x;
+			double v = uv.y;
 			
-			if ((v >= -0.5f * (float)Math.PI) && (v < 0.0f))
+			if ((v >= -0.5 * Math.PI) && (v < 0.0))
 			{
-				return startCap.GetPositionAt(new Vector2(u, v + 0.5f * (float)Math.PI));
+				return startCap.GetPositionAt(new dvec2(u, v + 0.5 * Math.PI));
 			}
-			else if ((v >= 0.0f) && (v < 1.0f))
+			else if ((v >= 0.0) && (v < 1.0))
 			{
-				return shaft.GetPositionAt(new Vector2(u, v));
+				return shaft.GetPositionAt(new dvec2(u, v));
 			}
-			else if ((v >= 1.0f) && (v <= 1.0f + 0.5f * (float)Math.PI))
+			else if ((v >= 1.0) && (v <= 1.0 + 0.5 * Math.PI))
 			{
-				return endCap.GetPositionAt(new Vector2(u, 1.0f + 0.5f * (float)Math.PI - v));
+				return endCap.GetPositionAt(new dvec2(u, 1.0 + 0.5 * Math.PI - v));
 			}
 			else
 			{
@@ -159,25 +160,25 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			// Recalculate the surface normal between the cylinder and the start cap:
 			for (int i = 0; i < (resolutionU - 1); i++)
 			{
-				Vector3 surfacePosition = startCapList[(resolutionU/4-1)*resolutionU + i + 1].Position;
-				Vector3 du = surfacePosition - startCapList[(resolutionU/4-1)*resolutionU + i + 1 + 1].Position;
-				Vector3 dv = surfacePosition - shaftSlice[i].Position;
+				dvec3 surfacePosition = startCapList[(resolutionU/4-1)*resolutionU + i + 1].Position;
+				dvec3 du = surfacePosition - startCapList[(resolutionU/4-1)*resolutionU + i + 1 + 1].Position;
+				dvec3 dv = surfacePosition - shaftSlice[i].Position;
 				
 				// Calculate the position of the rings of vertices:
-				Vector3 surfaceNormal = Vector3.Cross(Vector3.Normalize(du), Vector3.Normalize(dv));
+				dvec3 surfaceNormal = dvec3.Cross(du.Normalized, dv.Normalized);
 				
-				startCapList[(resolutionU/4-1)*resolutionU + i + 1] = new Vertex(surfacePosition, surfaceNormal);
+				startCapList[(resolutionU/4-1)*resolutionU + i + 1] = new Vertex((vec3)surfacePosition, (vec3)surfaceNormal);
 			}
 			
 			// Stitch the end of the triangles:
-			Vector3 surfacePosition2 = startCapList[(resolutionU/4-1)*resolutionU + resolutionU].Position;
-			Vector3 du2 = surfacePosition2 - startCapList[(resolutionU/4-1)*resolutionU + 1].Position;
-			Vector3 dv2 = surfacePosition2 - shaftSlice[resolutionU].Position;
+			dvec3 surfacePosition2 = startCapList[(resolutionU/4-1)*resolutionU + resolutionU].Position;
+			dvec3 du2 = surfacePosition2 - startCapList[(resolutionU/4-1)*resolutionU + 1].Position;
+			dvec3 dv2 = surfacePosition2 - shaftSlice[resolutionU].Position;
 			
 			// Calculate the position of the rings of vertices:
-			Vector3 surfaceNormal2 = Vector3.Cross(Vector3.Normalize(du2), Vector3.Normalize(dv2));
+			dvec3 surfaceNormal2 = dvec3.Cross(du2.Normalized, dv2.Normalized);
 			
-			startCapList[(resolutionU/4-1)*resolutionU + resolutionU] = new Vertex(surfacePosition2, surfaceNormal2);
+			startCapList[(resolutionU/4-1)*resolutionU + resolutionU] = new Vertex((vec3)surfacePosition2, (vec3)surfaceNormal2);
 			
 			return startCapList.Concat(shaftSlice).Concat(endCapList).ToList();
 		}

--- a/engine/geometry/Curve.cs
+++ b/engine/geometry/Curve.cs
@@ -14,9 +14,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
-using System;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -24,59 +23,59 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 	/// <summary>
 	///     A <c>Curve</c> defines any finite one-dimensional path in 3D space, with a start and end point.
 	/// </summary>
-	public abstract class Curve : ContinuousMap<float, Vector3>
+	public abstract class Curve : ContinuousMap<double, dvec3>
 	{
 		/// <summary>
 		///     Returns the position in 3D space of the curve based on the parametric variable <paramref name="t"/>.
 		/// </summary>
 		/// <param name="t">The parameter along the length of the curve. <paramref name="t"/> must be in the range
 		/// \f$[ 0, 1 ]\f$.</param>
-		public abstract Vector3 GetPositionAt(float t);
+		public abstract dvec3 GetPositionAt(double t);
 		
 		/// <summary>
 		///     Returns the tangent vector of the curve based on the parametric variable <paramref name="t"/>.
 		/// </summary>
 		/// <param name="t">The parameter along the length of the curve. <paramref name="t"/> must be in the range
 		/// \f$[ 0, 1 ]\f$.</param>
-		public abstract Vector3 GetTangentAt(float t);
+		public abstract dvec3 GetTangentAt(double t);
 		
 		/// <summary>
 		///     Returns the normal vector of the curve based on the parametric variable <paramref name="t"/>.
 		/// </summary>
 		/// <param name="t">The parameter along the length of the curve. <paramref name="t"/> must be in the range
 		/// \f$[ 0, 1 ]\f$.</param>
-		public abstract Vector3 GetNormalAt(float t);
+		public abstract dvec3 GetNormalAt(double t);
 		
 		/// <summary>
 		///     Returns the binormal vector of the curve based on the parametric variable <paramref name="t"/>.
 		/// </summary>
 		/// <param name="t">The parameter along the length of the curve. <paramref name="t"/> must be in the range
 		/// \f$[ 0, 1 ]\f$.</param>
-		public virtual Vector3 GetBinormalAt(float t)
+		public virtual dvec3 GetBinormalAt(double t)
 		{
-			return Vector3.Cross(GetTangentAt(t), GetNormalAt(t));
+			return dvec3.Cross(GetTangentAt(t), GetNormalAt(t));
 		}
 		
 		/// <summary>
 		///     Returns the position in 3D space of the start point of the curve.
 		///     Should return the same value as <c>getPositionAt(0.0)</c>.
 		/// </summary>
-		public virtual Vector3 GetStartPosition()
+		public virtual dvec3 GetStartPosition()
 		{
-			return GetPositionAt(0.0f);
+			return GetPositionAt(0.0);
 		}
 		
 		/// <summary>
 		///     Returns the position in 3D space of the end point of the curve.
 		///     Should return the same value as <c>getPositionAt(1.0)</c>.
 		/// </summary>
-		public virtual Vector3 GetEndPosition()
+		public virtual dvec3 GetEndPosition()
 		{
-			return GetPositionAt(1.0f);
+			return GetPositionAt(1.0);
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetValueAt(float t)
+		public override dvec3 GetValueAt(double t)
 		{
 			return GetPositionAt(t);
 		}

--- a/engine/geometry/Cylinder.cs
+++ b/engine/geometry/Cylinder.cs
@@ -15,9 +15,10 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
 using System;
 using System.Linq;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -48,12 +49,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <param name="radius">
 		/// 	<inheritdoc cref="Cylinder.Radius"/>
 		/// </param>
-		public Cylinder(Curve centerCurve, float radius)
+		public Cylinder(Curve centerCurve, double radius)
 		{
 			this.CenterCurve = centerCurve;
-			this.Radius = new ConstantFunction<Vector2, float>(radius);
-			this.StartAngle = 0.0f;
-			this.EndAngle = 2.0f * (float)Math.PI;
+			this.Radius = new ConstantFunction<dvec2, double>(radius);
+			this.StartAngle = 0.0;
+			this.EndAngle = 2.0 * Math.PI;
 		}
 		
 		/// <summary>
@@ -69,18 +70,18 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	and <c>endAngle</c>. For example, if <c>startAngle = 0.0f</c> and <c>endAngle = Math.PI</c>, one would
 		/// 	get a cylinder that is sliced in half.
 		/// </summary>
-		/// <param name="centerLine">
+		/// <param name="centerCurve">
 		/// 	<inheritdoc cref="SymmetricCylinder.CenterCurve"/>
 		/// </param>
 		/// <param name="radius">
 		/// 	<inheritdoc cref="SymmetricCylinder.Radius"/>
 		/// </param>
-		public Cylinder(Curve centerCurve, ContinuousMap<Vector2, float> radius)
+		public Cylinder(Curve centerCurve, ContinuousMap<dvec2, double> radius)
 		{
 			this.CenterCurve = centerCurve;
 			this.Radius = radius;
-			this.StartAngle = 0.0f;
-			this.EndAngle = 2.0f * (float)Math.PI;
+			this.StartAngle = 0.0;
+			this.EndAngle = 2.0 * (double)Math.PI;
 		}
 		
 		/// <summary>
@@ -96,7 +97,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	and <c>endAngle</c>. For example, if <c>startAngle = 0.0f</c> and <c>endAngle = Math.PI</c>, one would
 		/// 	get a cylinder that is sliced in half.
 		/// </summary>
-		/// <param name="centerLine">
+		/// <param name="centerCurve">
 		/// 	<inheritdoc cref="Cylinder.CenterCurve"/>
 		/// </param>
 		/// <param name="radius">
@@ -114,7 +115,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	the start point of the cylinder's central axis and \f$t=1\f$ is the end point of the cylinder's central
 		/// 	axis. This allows one to vary the angles of the pie-slice along the length of the shaft.
 		/// </param>
-		public Cylinder(Curve centerCurve, ContinuousMap<Vector2, float> radius, ContinuousMap<float, float> startAngle, ContinuousMap<float, float> endAngle)
+		public Cylinder(Curve centerCurve, ContinuousMap<dvec2, double> radius, ContinuousMap<double, double> startAngle, ContinuousMap<double, double> endAngle)
 		{
 			this.CenterCurve = centerCurve;
 			this.Radius = radius;
@@ -124,7 +125,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 #endregion Constructors
 
 #region Properties
-		protected ContinuousMap<Vector2, float> radius2D;
+		protected ContinuousMap<dvec2, double> radius2D;
 		
 		/// <summary>
 		/// 	The radius of the cylinder at each point on the central axis. Mathematically, <c>radius</c> is a
@@ -132,7 +133,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	the start point of the cylinder's central axis and \f$t=1\f$ is the end point of the cylinder's central
 		/// 	axis.
 		/// </summary>
-		public ContinuousMap<Vector2, float> Radius
+		public ContinuousMap<dvec2, double> Radius
 		{
 			get { return radius2D; }
 			set { radius2D = value; }
@@ -148,16 +149,16 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	one-dimensional function \f$\alpha(t)\f$ defined on the domain \f$t \in [0, 1]\f$, where \f$t=0\f$ is
 		/// 	the start point of the cylinder's central axis and \f$t=1\f$ is the end point of the cylinder's central
 		/// 	axis. This allows one to vary the angles of the pie-slice along the length of the shaft.
-		/// <summary>
-		public ContinuousMap<float, float> StartAngle { get; set; }
+		/// </summary>
+		public ContinuousMap<double, double> StartAngle { get; set; }
 		
 		/// <summary>
 		/// 	The end angle of the pie-slice at each point on the central axis. <c>endAngle</c> is a
 		/// 	one-dimensional function \f$\beta(t)\f$ defined on the domain \f$t \in [0, 1]\f$, where \f$t=0\f$ is
 		/// 	the start point of the cylinder's central axis and \f$t=1\f$ is the end point of the cylinder's central
 		/// 	axis. This allows one to vary the angles of the pie-slice along the length of the shaft.
-		/// <summary>
-		public ContinuousMap<float, float> EndAngle { get; set; }
+		/// </summary>
+		public ContinuousMap<double, double> EndAngle { get; set; }
 #endregion Properties
 
 #region Static Methods
@@ -180,28 +181,28 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 
 #region Base Class Method Overrides
 		/// <inheritdoc />
-		public override Vector3 GetNormalAt(Vector2 uv)
+		public override dvec3 GetNormalAt(dvec2 uv)
 		{
-			float u = uv.X;
-			float v = uv.Y;
+			double u = uv.x;
+			double v = uv.y;
 			
-			Vector3 curveTangent = Vector3.Normalize(CenterCurve.GetTangentAt(v));
-			Vector3 curveNormal = Vector3.Normalize(CenterCurve.GetNormalAt(v));
-			Vector3 curveBinormal = Vector3.Cross(curveTangent, curveNormal);
+			dvec3 curveTangent = CenterCurve.GetTangentAt(v).Normalized;
+			dvec3 curveNormal = CenterCurve.GetNormalAt(v).Normalized;
+			dvec3 curveBinormal = dvec3.Cross(curveTangent, curveNormal);
 			
-			float startAngle = StartAngle.GetValueAt(v);
-			float endAngle = EndAngle.GetValueAt(v);
+			double startAngle = StartAngle.GetValueAt(v);
+			double endAngle = EndAngle.GetValueAt(v);
 			
-			return (float)Math.Cos(u)*curveNormal + (float)Math.Sin(u)*curveBinormal;
+			return Math.Cos(u)*curveNormal + Math.Sin(u)*curveBinormal;
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetPositionAt(Vector2 uv)
+		public override dvec3 GetPositionAt(dvec2 uv)
 		{
-			float v = uv.Y;
+			double v = uv.y;
 				
-			Vector3 translation = CenterCurve.GetPositionAt(v);
-			float radius = Radius.GetValueAt(uv);
+			dvec3 translation = CenterCurve.GetPositionAt(v);
+			double radius = Radius.GetValueAt(uv);
 			
 			return translation + radius*GetNormalAt(uv);
 		}
@@ -211,28 +212,28 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		{
 			var roughs = ParallelEnumerable.Range(0, resolutionV + 1).AsOrdered().SelectMany((j =>
 			{
-				float v = (float) j / (float) resolutionV;
+				double v = (double) j / (double) resolutionV;
 
 				// Find the values at each ring:
-				Vector3 curveTangent = Vector3.Normalize(CenterCurve.GetTangentAt(v));
-				Vector3 curveNormal = Vector3.Normalize(CenterCurve.GetNormalAt(v));
-				Vector3 curveBinormal = Vector3.Cross(curveTangent, curveNormal);
+				dvec3 curveTangent = CenterCurve.GetTangentAt(v).Normalized;
+				dvec3 curveNormal = CenterCurve.GetNormalAt(v).Normalized;
+				dvec3 curveBinormal = dvec3.Cross(curveTangent, curveNormal);
 
-				Vector3 translation = CenterCurve.GetPositionAt(v);
+				dvec3 translation = CenterCurve.GetPositionAt(v);
 
-				float startAngle = StartAngle.GetValueAt(v);
-				float endAngle = EndAngle.GetValueAt(v);
+				double startAngle = StartAngle.GetValueAt(v);
+				double endAngle = EndAngle.GetValueAt(v);
 
 				return Enumerable.Range(0, resolutionU).Select((i) =>
 				{
-					float u = startAngle + (endAngle - startAngle) * (float) i / (float) resolutionU;
+					double u = startAngle + (endAngle - startAngle) * (double) i / (double) resolutionU;
 
-					float radius = Radius.GetValueAt(new Vector2(u, v));
+					double radius = Radius.GetValueAt(new dvec2(u, v));
 
 					// Calculate the position of the rings of vertices:
-					Vector3 surfaceNormal = (float) Math.Cos(u) * curveNormal + (float) Math.Sin(u) * curveBinormal;
-					Vector3 surfacePosition = translation + radius * surfaceNormal;
-					return new Vertex(surfacePosition, surfaceNormal);
+					dvec3 surfaceNormal = (double) Math.Cos(u) * curveNormal + (double) Math.Sin(u) * curveBinormal;
+					dvec3 surfacePosition = translation + radius * surfaceNormal;
+					return new Vertex((vec3)surfacePosition, (vec3)surfaceNormal);
 				});
 			}));
 
@@ -243,25 +244,25 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			{
 				for (int i = 0; i < (resolutionU - 1); i++)
 				{
-					Vector3 surfacePosition = output[(j-1)*resolutionU + i].Position;
-					Vector3 du = surfacePosition - output[(j-1)*resolutionU + i + 1].Position;
-					Vector3 dv = surfacePosition - output[(j)*resolutionU + i].Position;
+					dvec3 surfacePosition = output[(j-1)*resolutionU + i].Position;
+					dvec3 du = surfacePosition - output[(j-1)*resolutionU + i + 1].Position;
+					dvec3 dv = surfacePosition - output[(j)*resolutionU + i].Position;
 					
 					// Calculate the position of the rings of vertices:
-					Vector3 surfaceNormal = Vector3.Cross(Vector3.Normalize(du), Vector3.Normalize(dv));
+					dvec3 surfaceNormal = dvec3.Cross(du.Normalized, dv.Normalized);
 					
-					output[(j-1)*resolutionU + i] = new Vertex(surfacePosition, surfaceNormal);
+					output[(j-1)*resolutionU + i] = new Vertex((vec3)surfacePosition, (vec3)surfaceNormal);
 				}
 				
 				// Stitch the end of the triangles:
-				Vector3 surfacePosition2 = output[(j-1)*resolutionU + resolutionU-1].Position;
-				Vector3 du2 = surfacePosition2 - output[(j-1)*resolutionU].Position;
-				Vector3 dv2 = surfacePosition2 - output[(j)*resolutionU + resolutionU-1].Position;
+				dvec3 surfacePosition2 = output[(j-1)*resolutionU + resolutionU-1].Position;
+				dvec3 du2 = surfacePosition2 - output[(j-1)*resolutionU].Position;
+				dvec3 dv2 = surfacePosition2 - output[(j)*resolutionU + resolutionU-1].Position;
 				
 				// Calculate the position of the rings of vertices:
-				Vector3 surfaceNormal2 = Vector3.Cross(Vector3.Normalize(du2), Vector3.Normalize(dv2));
+				dvec3 surfaceNormal2 = dvec3.Cross(du2.Normalized, dv2.Normalized);
 				
-				output[(j-1)*resolutionU + resolutionU-1] = new Vertex(surfacePosition2, surfaceNormal2);
+				output[(j-1)*resolutionU + resolutionU-1] = new Vertex((vec3)surfacePosition2, (vec3)surfaceNormal2);
 			}
 			
 			return output;

--- a/engine/geometry/IRaytraceableSurface.cs
+++ b/engine/geometry/IRaytraceableSurface.cs
@@ -29,6 +29,6 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <param name="ray">
 		///		The Ray object that defines the starting point and direction of the ray to be cast.
 		/// </param>
-		float RayIntersect(Ray ray);
+		double RayIntersect(Ray ray);
 	}
 }

--- a/engine/geometry/LineSegment.cs
+++ b/engine/geometry/LineSegment.cs
@@ -14,9 +14,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Numerics;
-using System;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 {
@@ -25,61 +23,61 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 	/// </summary>
 	public class LineSegment : Curve
 	{
-		private Vector3 start;
-		private Vector3 end;
-		private Vector3 normal;
+		private dvec3 _start;
+		private dvec3 _end;
+		private dvec3 _normal;
 		
-		public LineSegment(Vector3 start, Vector3 end)
+		public LineSegment(dvec3 start, dvec3 end)
 		{
-			this.start = start;
-			this.end = end;
-			
+			_start = start;
+			_end = end;
+
 			// No normal supplied, pick arbitrary normal vector:
-			this.normal = VectorUtilities.InventNormal(end - start);
+			_normal = VectorUtilities.InventNormal(end - start);
 		}
 		
-		public LineSegment(Vector3 start, Vector3 end, Vector3 normal)
+		public LineSegment(dvec3 start, dvec3 end, dvec3 normal)
 		{
-			this.start = start;
-			this.end = end;
+			_start = start;
+			_end = end;
 			
 			// Ensure that the normal is truly perpendicular to the tangent vector:
-			Vector3 tangent = Vector3.Normalize(end - start);
-			Vector3 up = Vector3.Normalize(Vector3.Cross(tangent, normal));
-			this.normal = Vector3.Normalize(Vector3.Cross(up, tangent));
+			dvec3 tangent = (end - start).Normalized;
+			dvec3 up = dvec3.Cross(tangent, normal).Normalized;
+			_normal = dvec3.Cross(up, tangent).Normalized;
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetPositionAt(float t)
+		public override dvec3 GetPositionAt(double t)
 		{
 			// Simply return the linearly interpolated position between `start` and `end`:
-			return t*end + (1.0f-t)*start;
+			return t*_end + (1.0-t)*_start;
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetTangentAt(float t)
+		public override dvec3 GetTangentAt(double t)
 		{
 			// The tangent vector is always in the direction of the line:
-			return end - start; // TODO: Should this be normalized, or is length information useful?
+			return _end - _start; // TODO: Should this be normalized, or is length information useful?
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetNormalAt(float t)
+		public override dvec3 GetNormalAt(double t)
 		{
 			// The tangent vector is always in the direction of the line:
-			return normal; // TODO: Should this be normalized, or is length information useful?
+			return _normal; // TODO: Should this be normalized, or is length information useful?
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetStartPosition()
+		public override dvec3 GetStartPosition()
 		{
-			return start;
+			return _start;
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetEndPosition()
+		public override dvec3 GetEndPosition()
 		{
-			return end;
+			return _end;
 		}
 	}
 }

--- a/engine/geometry/Mesh.cs
+++ b/engine/geometry/Mesh.cs
@@ -1,5 +1,21 @@
+/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ * 
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 using System.Collections.Generic;
-using System.Numerics;
+
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Renderable
@@ -8,10 +24,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Renderable
 	{
 		public UVMesh(Surface surface, int resolutionU, int resolutionV, int indexOffset = 0)
 		{
-			this.VertexList = surface.GenerateVertexList(resolutionU, resolutionV);
-			this.IndexList = surface.GenerateIndexList(resolutionU, resolutionV, indexOffset);
-			this.ResolutionU = resolutionU;
-			this.ResolutionV = resolutionV;
+			VertexList = surface.GenerateVertexList(resolutionU, resolutionV);
+			IndexList = surface.GenerateIndexList(resolutionU, resolutionV, indexOffset);
+			ResolutionU = resolutionU;
+			ResolutionV = resolutionV;
 		}
 		
 		public int ResolutionU { get; }

--- a/engine/geometry/Ray.cs
+++ b/engine/geometry/Ray.cs
@@ -14,9 +14,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections;
-using System.Numerics;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 {
@@ -28,15 +26,15 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <summary>
 		///		The point from which the ray is cast.
 		/// </summary>
-		public Vector3 StartPosition { get; set; }
+		public dvec3 StartPosition { get; set; }
 		
-		Vector3 direction;
+		dvec3 direction;
 		/// <summary>
 		///		The direction in which the ray is cast. The direction becomes normalized on assignment.
 		/// </summary>
-		public Vector3 Direction {
+		public dvec3 Direction {
 			get { return direction; }
-			set { direction = Vector3.Normalize(value); }
+			set { direction = value.Normalized; }
 		}
 		
 		/// <summary>
@@ -48,10 +46,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <param name="rayDirection">
 		///		The direction in which the ray is cast. The direction becomes normalized on initialization.
 		/// </param>
-		public Ray(Vector3 rayStart, Vector3 rayDirection)
+		public Ray(dvec3 rayStart, dvec3 rayDirection)
 		{
 			StartPosition = rayStart;
-			direction = Vector3.Normalize(rayDirection);
+			direction = rayDirection.Normalized;
 		}
 	}
 }

--- a/engine/geometry/SpatialCubicSpline.cs
+++ b/engine/geometry/SpatialCubicSpline.cs
@@ -15,8 +15,8 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
-using System;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -48,9 +48,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// </summary>
 		public SpatialCubicSpline(CubicSpline1D x, CubicSpline1D y, CubicSpline1D z)
 		{
-			this.X = x;
-			this.Y = y;
-			this.Z = z;
+			X = x;
+			Y = y;
+			Z = z;
 			
 			GenerateCurveNormal();
 		}
@@ -58,29 +58,29 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <summary>
 		/// 	Construct a new 3D cubic spline using three lists of points defining one-dimensional cubic splines.
 		/// </summary>
-		public SpatialCubicSpline(SortedList<float, float> x, SortedList<float, float> y, SortedList<float, float> z)
+		public SpatialCubicSpline(SortedList<double, double> x, SortedList<double, double> y, SortedList<double, double> z)
 			: this(new CubicSpline1D(x), new CubicSpline1D(y), new CubicSpline1D(z)) { }
 		
 		/// <summary>
 		/// 	Construct a new 3D cubic spline using a list of 3D points.
 		/// </summary>
-		public SpatialCubicSpline(SortedList<float, Vector3> points)
+		public SpatialCubicSpline(SortedList<double, dvec3> points)
 		{
 			// Note: slow implementation, can be optimized in C++.
-			SortedList<float, float> x = new SortedList<float, float>();
-			SortedList<float, float> y = new SortedList<float, float>();
-			SortedList<float, float> z = new SortedList<float, float>();
+			SortedList<double, double> x = new SortedList<double, double>();
+			SortedList<double, double> y = new SortedList<double, double>();
+			SortedList<double, double> z = new SortedList<double, double>();
 			
 			foreach (var item in points)
 			{
-				x.Add(item.Key, item.Value.X);
-				y.Add(item.Key, item.Value.Y);
-				z.Add(item.Key, item.Value.Z);
+				x.Add(item.Key, item.Value.x);
+				y.Add(item.Key, item.Value.y);
+				z.Add(item.Key, item.Value.z);
 			}
 			
-			this.X = new CubicSpline1D(x);
-			this.Y = new CubicSpline1D(y);
-			this.Z = new CubicSpline1D(z);
+			X = new CubicSpline1D(x);
+			Y = new CubicSpline1D(y);
+			Z = new CubicSpline1D(z);
 			
 			GenerateCurveNormal();
 		}
@@ -88,38 +88,38 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		
 #region Base Class Method Overrides
 		/// <inheritdoc />
-		public override Vector3 GetPositionAt(float t)
+		public override dvec3 GetPositionAt(double t)
 		{
 			// Return the components of each 1D spline to get a 3D spline:
-			return new Vector3(X.GetValueAt(t), Y.GetValueAt(t), Z.GetValueAt(t));
+			return new dvec3(X.GetValueAt(t), Y.GetValueAt(t), Z.GetValueAt(t));
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetTangentAt(float t)
+		public override dvec3 GetTangentAt(double t)
 		{
 			// The tangent vector is always in the direction of the line:
-			return new Vector3(X.GetDerivativeAt(t), Y.GetDerivativeAt(t), Z.GetDerivativeAt(t)); // TODO: Should this be normalized, or is length information useful?
+			return new dvec3(X.GetDerivativeAt(t), Y.GetDerivativeAt(t), Z.GetDerivativeAt(t)); // TODO: Should this be normalized, or is length information useful?
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetNormalAt(float t)
+		public override dvec3 GetNormalAt(double t)
 		{
-			Vector3 direction = Vector3.Normalize(GetTangentAt(t));
-			Vector3 normal = new Vector3(NormalX.GetValueAt(t), NormalY.GetValueAt(t), NormalZ.GetValueAt(t));
-			Vector3 up = Vector3.Cross(direction, normal);
-			return Vector3.Normalize(Vector3.Cross(up, direction));
+			dvec3 direction = GetTangentAt(t).Normalized;
+			dvec3 normal = new dvec3(NormalX.GetValueAt(t), NormalY.GetValueAt(t), NormalZ.GetValueAt(t));
+			dvec3 up = dvec3.Cross(direction, normal);
+			return dvec3.Cross(up, direction).Normalized;
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetStartPosition()
+		public override dvec3 GetStartPosition()
 		{
-			return new Vector3(X.GetValueAt(0.0f), Y.GetValueAt(0.0f), Z.GetValueAt(0.0f));
+			return new dvec3(X.GetValueAt(0.0), Y.GetValueAt(0.0), Z.GetValueAt(0.0));
 		}
 		
 		/// <inheritdoc />
-		public override Vector3 GetEndPosition()
+		public override dvec3 GetEndPosition()
 		{
-			return new Vector3(X.GetValueAt(1.0f), Y.GetValueAt(1.0f), Z.GetValueAt(1.0f));
+			return new dvec3(X.GetValueAt(1.0), Y.GetValueAt(1.0), Z.GetValueAt(1.0));
 		}
 #endregion Base Class Method Overrides
 		
@@ -135,34 +135,34 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			// Generate a tangent at key points:
 			// TODO: make the precision adapt to the precision of centerCurve!
 			
-			SortedList<float, float> normalX = new SortedList<float, float>();
-			SortedList<float, float> normalY = new SortedList<float, float>();
-			SortedList<float, float> normalZ = new SortedList<float, float>();
-			
+			SortedList<double, double> normalX = new SortedList<double, double>();
+			SortedList<double, double> normalY = new SortedList<double, double>();
+			SortedList<double, double> normalZ = new SortedList<double, double>();
+
 			// No normal supplied, pick arbitrary normal vector and calculate a binormal:
-			Vector3 binormal = Vector3.Cross(VectorUtilities.InventNormal(GetTangentAt(0.0f)), GetTangentAt(0.0f));
+			dvec3 binormal = dvec3.Cross(VectorUtilities.InventNormal(GetTangentAt(0.0)), GetTangentAt(0.0));
 			
 			// Traverse through all the points in the spline, and calculate the next normal, maintaining smoothness by
 			// memorizing the previous normal:
 			
-			float previousValue = X.Points.Key[0]; // Location.Points.Key is guaranteed to have at least 2 entries, this is safe.
+			double previousValue = X.Points.Key[0]; // Location.Points.Key is guaranteed to have at least 2 entries, this is safe.
 			for (int i = 1; i < X.Points.Count; i++)
 			{
-				float currentValue = X.Points.Key[i];
-				float segmentSize = currentValue - previousValue;
+				double currentValue = X.Points.Key[i];
+				double segmentSize = currentValue - previousValue;
 				
 				// Interpolate between each two points:
 				for (int j = 0; j < kInterpolationStepCount; j++)
 				{
-					float t = previousValue + segmentSize*(float)j/(float)kInterpolationStepCount;
-					
-					Vector3 direction = Vector3.Normalize(GetTangentAt(t));
-					Vector3 normal = Vector3.Normalize(Vector3.Cross(direction, binormal));
-					binormal = Vector3.Cross(normal, direction);
-					
-					normalX.Add(t, normal.X);
-					normalY.Add(t, normal.Y);
-					normalZ.Add(t, normal.Z);
+					double t = previousValue + segmentSize*j/kInterpolationStepCount;
+
+					dvec3 direction = GetTangentAt(t).Normalized;
+					dvec3 normal = dvec3.Cross(direction, binormal).Normalized;
+					binormal = dvec3.Cross(normal, direction);
+
+					normalX.Add(t, normal.x);
+					normalY.Add(t, normal.y);
+					normalZ.Add(t, normal.z);
 				}
 				
 				previousValue = currentValue;
@@ -170,20 +170,20 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			
 			// Add the final point as well:
 			{
-				float t = X.Points.Key[X.Points.Count - 1];
+				double t = X.Points.Key[X.Points.Count - 1];
 				
-				Vector3 direction = Vector3.Normalize(GetTangentAt(t));
-				Vector3 normal = Vector3.Normalize(Vector3.Cross(direction, binormal));
-				binormal = Vector3.Cross(normal, direction);
-				
-				normalX.Add(t, normal.X);
-				normalY.Add(t, normal.Y);
-				normalZ.Add(t, normal.Z);
+				dvec3 direction = GetTangentAt(t).Normalized;
+				dvec3 normal = dvec3.Cross(direction, binormal).Normalized;
+				binormal = dvec3.Cross(normal, direction);
+
+				normalX.Add(t, normal.x);
+				normalY.Add(t, normal.y);
+				normalZ.Add(t, normal.z);
 			}
 			
-			this.NormalX = new CubicSpline1D(normalX);
-			this.NormalY = new CubicSpline1D(normalY);
-			this.NormalZ = new CubicSpline1D(normalZ);
+			NormalX = new CubicSpline1D(normalX);
+			NormalY = new CubicSpline1D(normalY);
+			NormalZ = new CubicSpline1D(normalZ);
 		}
 #endregion Private Methods
 	}

--- a/engine/geometry/Surface.cs
+++ b/engine/geometry/Surface.cs
@@ -1,5 +1,22 @@
+/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ * 
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 using System.Collections.Generic;
-using System.Numerics;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Renderable;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -9,12 +26,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <summary>
 		///     Returns the surface normal at the uv coordinate given.
 		/// </summary>
-		public abstract Vector3 GetNormalAt(Vector2 uv);
+		public abstract dvec3 GetNormalAt(dvec2 uv);
 		
 		/// <summary>
 		///     Returns the surface position at the uv coordinate given.
 		/// </summary>
-		public abstract Vector3 GetPositionAt(Vector2 uv);
+		public abstract dvec3 GetPositionAt(dvec2 uv);
 		
 		/// <summary>
 		///     Generates the vertex positions of this uv-parametrized surface. The returned list will contain

--- a/engine/geometry/SymmetricCylinder.cs
+++ b/engine/geometry/SymmetricCylinder.cs
@@ -15,8 +15,9 @@
  */
 
 using System.Collections.Generic;
-using System.Numerics;
 using System;
+using GlmSharp;
+
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
@@ -45,7 +46,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	<inheritdoc cref="SymmetricCylinder.Radius"/>
 		/// </param>
 		public SymmetricCylinder(LineSegment centerLine, RaytraceableFunction1D radius)
-			: this(centerLine, radius, 0.0f, 2.0f*(float)Math.PI)
+			: this(centerLine, radius, 0.0, 2.0 * Math.PI)
 		{
 			
 		}
@@ -81,8 +82,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// 	the start point of the cylinder's central axis and \f$t=1\f$ is the end point of the cylinder's central
 		/// 	axis. This allows one to vary the angles of the pie-slice along the length of the shaft.
 		/// </param>
-		public SymmetricCylinder(LineSegment centerLine, RaytraceableFunction1D radius, ContinuousMap<float, float> startAngle, ContinuousMap<float, float> endAngle)
-			: base(centerLine, new DomainToVector2<float>(new Vector2(0.0f, 1.0f), radius), startAngle, endAngle)
+		public SymmetricCylinder(LineSegment centerLine, RaytraceableFunction1D radius, ContinuousMap<double, double> startAngle, ContinuousMap<double, double> endAngle)
+			: base(centerLine, new DomainToVector2<double>(dvec2.UnitY, radius), startAngle, endAngle)
 		{
 			radius1D = radius;
 			this.centerLine = centerLine;
@@ -100,7 +101,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			get { return radius1D; }
 			set {
 				radius1D = value;
-				radius2D = new DomainToVector2<float>(new Vector2(0.0f, 1.0f), value);
+				radius2D = new DomainToVector2<double>(dvec2.UnitY, value);
 			}
 		}
 		
@@ -121,82 +122,79 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 
 #region IRaytraceableSurface
 		/// <inheritdoc />
-		public float RayIntersect(Ray ray)
+		public double RayIntersect(Ray ray)
 		{
-			Vector3 rayStart = ray.StartPosition;
-			Vector3 rayDirection = ray.Direction;
+			dvec3 rayStart = ray.StartPosition;
+			dvec3 rayDirection = ray.Direction;
 			
 			// Since we raytrace only using a cylindrical surface that is horizontal and at the origin, we
 			// first shift and rotate the ray such that we get the right orientation:
-			Vector3 start = CenterCurve.GetStartPosition();
-			Vector3 end = CenterCurve.GetEndPosition();
+			dvec3 start = CenterCurve.GetStartPosition();
+			dvec3 end = CenterCurve.GetEndPosition();
 			
-			Vector3 tangent = Vector3.Normalize(CenterCurve.GetTangentAt(0.0f));
-			Vector3 normal = Vector3.Normalize(CenterCurve.GetNormalAt(0.0f));
-			Vector3 binormal = Vector3.Normalize(CenterCurve.GetBinormalAt(0.0f));
+			dvec3 tangent = CenterCurve.GetTangentAt(0.0).Normalized;
+			dvec3 normal = CenterCurve.GetNormalAt(0.0).Normalized;
+			dvec3 binormal = CenterCurve.GetBinormalAt(0.0).Normalized;
 			
-			float length = Vector3.Distance(start, end);
+			double length = dvec3.Distance(start, end);
 			
 			// CenterCurve is guaranteed to be a LineSegment, since the base property CenterCurve is masked by this
 			// class' CenterCurve property that only accepts a LineSegment, and similarly this class' constructor only
 			// accepts a LineSegment. The following mathematics, which assumes that the central axis is a line segment,
 			// is therefore valid.
+
+			dmat3 rotationMatrix = new dmat3(normal, binormal, tangent/length).Transposed;
 			
-			Matrix4x4 rotationMatrix = new Matrix4x4(normal.X, binormal.X, tangent.X/length, 0.0f,
-			                                         normal.Y, binormal.Y, tangent.Y/length, 0.0f,
-			                                         normal.Z, binormal.Z, tangent.Z/length, 0.0f,
-			                                         0.0f, 0.0f,   0.0f,  1.0f);
+			dvec3 rescaledRay = rotationMatrix * (rayStart - start);
+			dvec3 newDirection = rotationMatrix * rayDirection.Normalized;
 			
-			Vector3 rescaledRay = Vector3.Transform(rayStart - start, rotationMatrix);
-			Vector3 newDirection = Vector3.TransformNormal(Vector3.Normalize(rayDirection), rotationMatrix);
+
+			double x0 = rescaledRay.x;
+			double y0 = rescaledRay.y;
+			double z0 = rescaledRay.z;
 			
-			
-			float x0 = rescaledRay.X;
-			float y0 = rescaledRay.Y;
-			float z0 = rescaledRay.Z;
-			
-			float a = newDirection.X;
-			float b = newDirection.Y;
-			float c = newDirection.Z;
+			double a = newDirection.x;
+			double b = newDirection.y;
+			double c = newDirection.z;
 			
 			// Raytrace using a cylindrical surface equation x^2 + y^2. The parameters in the following line
 			// represent the coefficients of the expanded cylindrical surface equation, after the substitution
 			// x = x_0 + a t and y = y_0 + b t:
-			QuarticFunction surfaceFunction = new QuarticFunction(x0*x0 + y0*y0, 2.0f*(x0*a + y0*b), a*a + b*b, 0.0f, 0.0f);
+			QuarticFunction surfaceFunction = new QuarticFunction(x0*x0 + y0*y0, 2.0*(x0*a + y0*b), a*a + b*b, 0.0, 0.0);
 			
-			IEnumerable<float> intersections = Radius.SolveRaytrace(surfaceFunction, z0, c);
+			IEnumerable<double> intersections = Radius.SolveRaytrace(surfaceFunction, z0, c);
 			
 			// The previous function returns a list of intersection distances. The value closest to 0.0f represents the
 			// closest intersection point.
-			float minimum = Single.PositiveInfinity;
+			double minimum = Single.PositiveInfinity;
 			
-			foreach (float i in intersections)
+			foreach (double i in intersections)
 			{
 				// Calculate the 3d point at which the ray intersects the cylinder:
-				Vector3 intersectionPoint = rayStart + i*rayDirection;
+				dvec3 intersectionPoint = rayStart + i*rayDirection;
 				
 				// Find the closest point to the intersectionPoint on the centerLine.
 				// Get the vector v from the start of the cylinder to the intersection point:
-				Vector3 v = intersectionPoint - start;
+				dvec3 v = intersectionPoint - start;
 				
 				// ...And project this vector onto the center line:
-				float t = -Vector3.Dot(intersectionPoint, tangent*length)/(length*length);
+				double t = -dvec3.Dot(intersectionPoint, tangent*length)/(length*length);
 				
 				// Now we have the parameter t on the surface of the SymmetricCylinder at which the ray intersects.
 				
 				// Find the angle to the normal of the centerLine, so that we can determine whether the
 				// angle is within the bound of the pie-slice at position t:
-				Vector3 centerLineNormal = CenterCurve.GetNormalAt(t);
-				Vector3 centerLineBinormal = CenterCurve.GetBinormalAt(t);
-				Vector3 d = intersectionPoint - CenterCurve.GetPositionAt(t);
-				float correctionShift = (float)Math.Sign(Vector3.Dot(d, centerLineBinormal));
-				float phi = (correctionShift*(float)Math.Acos(Vector3.Dot(d, centerLineNormal))) % (2.0f*(float)Math.PI);
+				dvec3 centerLineNormal = CenterCurve.GetNormalAt(t);
+				dvec3 centerLineBinormal = CenterCurve.GetBinormalAt(t);
+				dvec3 d = intersectionPoint - CenterCurve.GetPositionAt(t);
+				double correctionShift = Math.Sign(dvec3.Dot(d, centerLineBinormal));
+				double phi = (correctionShift * Math.Acos(dvec3.Dot(d, centerLineNormal))) % (2.0*Math.PI);
 				
 				// Determine if the ray is inside the pie-slice of the cylinder that is being displayed,
 				// otherwise discard:
-				if ( phi > StartAngle.GetValueAt(t) && phi < EndAngle.GetValueAt(t) && i >= 0.0f)
+				if ( phi > StartAngle.GetValueAt(t) && phi < EndAngle.GetValueAt(t) && i >= 0.0)
 				{
-					minimum = Math.Sign(i)*(float)Math.Min(Math.Abs(minimum), Math.Abs(i));
+					minimum = Math.Sign(i) * Math.Min(Math.Abs(minimum), Math.Abs(i));
 				}
 			}
 			

--- a/engine/geometry/Vertex.cs
+++ b/engine/geometry/Vertex.cs
@@ -1,28 +1,43 @@
+/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ * 
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 using System;
-using System.Collections;
-using System.Numerics;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 {
 	public struct Vertex
 	{
-		public Vertex(Vector3 position)
+		public Vertex(vec3 position)
 		{
-			this.Position = position;
-			this.Normal = new Vector3(0.0f, 0.0f, 1.0f);
-		}
-		
-		public Vertex(Vector3 position, Vector3 normal)
-		{
-			this.Position = position;
-			this.Normal = normal;
+			Position = position;
+			Normal = new vec3(0.0f, 0.0f, 1.0f);
 		}
 
-		public Vector3 Position {get; set;}
-		public Vector3 Normal {get; set;}
+		public Vertex(vec3 position, vec3 normal)
+		{
+			Position = position;
+			Normal = normal;
+		}
+
+		public vec3 Position {get; set;}
+		public vec3 Normal {get; set;}
 		
 		public override String ToString() {
-			return this.Position.ToString();
+			return Position.ToString();
 		}
 	}
 }

--- a/engine/utilities/VectorUtilities.cs
+++ b/engine/utilities/VectorUtilities.cs
@@ -14,8 +14,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Numerics;
 using System;
+using GlmSharp;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
@@ -29,32 +29,65 @@ namespace FreedomOfFormFoundation.AnatomyEngine
 		/// <c>v</c>. The result is not guaranteed to satisfy any properties other than that it is normal to vector
 		/// <c>v</c>, and is normalized.
 		/// </summary>
-		public static Vector3 InventNormal(Vector3 v)
+		public static dvec3 InventNormal(dvec3 v)
 		{
-			// If the vector has infinite or NaN components, throw an error:
-			if (Single.IsNaN(Vector3.Dot(Vector3.One, v)) || Single.IsInfinity(Vector3.Dot(Vector3.One, v)))
+			// If the vector has any infinite or NaN components, throw an error:
+			if (Double.IsNaN(dvec3.Dot(dvec3.Ones, v)) || Double.IsInfinity(dvec3.Dot(dvec3.Ones, v)))
 			{
-				throw new ArgumentException("Vector must not contain infinite or NaN values.", "v");
+				throw new ArgumentException("Vector must not contain infinite or NaN values.", nameof(v));
 			}
 			
 			// TODO: Here it would be nice to add IsNormal instead of an arbitrary comparison, but alas... it's only
 			// supported in .NET 5.0 which we can't target yet.
-			if ((Math.Abs(v.X) < 0.001) && (Math.Abs(v.Y) < 0.001) && (Math.Abs(v.Z) < 0.001))
+			if ((Math.Abs(v.x) < 0.001) && (Math.Abs(v.y) < 0.001) && (Math.Abs(v.z) < 0.001))
 			{
-				throw new ArgumentException("Vector is too small.", "v");
+				throw new ArgumentException("Vector is too small.", nameof(v));
 			}
 			
-			Vector3 normalizedV = Vector3.Normalize(v);
-			Vector3 up = Vector3.UnitZ;
+			dvec3 normalizedV = v.Normalized;
+			dvec3 up = dvec3.UnitZ;
 			
 			// If the vector is pointing in the same direction as the up vector, the cross product can not be trusted.
 			// So we use a different up vector.
-			if (Math.Sign(normalizedV.Z) > 1/Math.Sqrt(2))
+			if (Math.Sign(normalizedV.z) > 1/Math.Sqrt(2))
 			{
-				up = Vector3.UnitY;
+				up = dvec3.UnitY;
 			}
 			
-			return Vector3.Normalize(Vector3.Cross(normalizedV, up));
+			return dvec3.Cross(normalizedV, up).Normalized;
+		}
+
+		/// <summary>
+		/// Invent a new, arbitrary normal to a vector by using a cross product between one of the axis vectors and
+		/// <c>v</c>. The result is not guaranteed to satisfy any properties other than that it is normal to vector
+		/// <c>v</c>, and is normalized.
+		/// </summary>
+		public static vec3 InventNormal(vec3 v)
+		{
+			// If the vector has any infinite or NaN components, throw an error:
+			if (Single.IsNaN(vec3.Dot(vec3.Ones, v)) || Single.IsInfinity(vec3.Dot(vec3.Ones, v)))
+			{
+				throw new ArgumentException("Vector must not contain infinite or NaN values.", nameof(v));
+			}
+
+			// TODO: Here it would be nice to add IsNormal instead of an arbitrary comparison, but alas... it's only
+			// supported in .NET 5.0 which we can't target yet.
+			if ((Math.Abs(v.x) < 0.001) && (Math.Abs(v.y) < 0.001) && (Math.Abs(v.z) < 0.001))
+			{
+				throw new ArgumentException("Vector is too small.", nameof(v));
+			}
+
+			vec3 normalizedV = v.Normalized;
+			vec3 up = vec3.UnitZ;
+
+			// If the vector is pointing in the same direction as the up vector, the cross product can not be trusted.
+			// So we use a different up vector.
+			if (Math.Sign(normalizedV.z) > 1 / Math.Sqrt(2))
+			{
+				up = vec3.UnitY;
+			}
+
+			return vec3.Cross(normalizedV, up).Normalized;
 		}
 	}
 }

--- a/gui/ExampleBone.cs
+++ b/gui/ExampleBone.cs
@@ -1,11 +1,9 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using Numerics = System.Numerics;
+using GlmSharp;
 
-using FreedomOfFormFoundation.AnatomyEngine;
 using Anatomy = FreedomOfFormFoundation.AnatomyEngine.Anatomy;
-using FreedomOfFormFoundation.AnatomyEngine.Anatomy.Bones;
 using FreedomOfFormFoundation.AnatomyEngine.Geometry;
 using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 using FreedomOfFormFoundation.AnatomyEngine.Renderable;
@@ -33,7 +31,7 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 		public void CreateExampleBones(Anatomy.Skeleton skeleton)
 		{
 			// Generate a simple cubic spline that will act as the radius of a long bone:
-			SortedList<float, float> radiusPoints = new SortedList<float, float>();
+			SortedList<double, double> radiusPoints = new SortedList<double, double>();
 			radiusPoints.Add(-3.5f, 0.7f*1.2f);
 			radiusPoints.Add(-1.0f, 0.7f*1.2f);
 			radiusPoints.Add(0.02f, 0.7f*1.2f);
@@ -46,18 +44,18 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			LinearSpline1D boneRadius = new LinearSpline1D(radiusPoints);
 
 			// Define the center curve of the long bone:
-			SortedList<float, Numerics.Vector3> centerPoints = new SortedList<float, Numerics.Vector3>();
-			centerPoints.Add(0.0f, new Numerics.Vector3(0.0f, 0.0f, 2.7f));
-			centerPoints.Add(0.25f, new Numerics.Vector3(-0.3f, -0.5f, 1.0f));
-			centerPoints.Add(0.5f, new Numerics.Vector3(0.3f, 1.0f, 0.0f));
-			centerPoints.Add(0.75f, new Numerics.Vector3(0.8f, 1.0f, -1.0f));
-			centerPoints.Add(1.0f, new Numerics.Vector3(0.6f, -0.5f, -0.9f));
+			SortedList<double, dvec3> centerPoints = new SortedList<double, dvec3>();
+			centerPoints.Add(0.0f, new dvec3(0.0f, 0.0f, 2.7f));
+			centerPoints.Add(0.25f, new dvec3(-0.3f, -0.5f, 1.0f));
+			centerPoints.Add(0.5f, new dvec3(0.3f, 1.0f, 0.0f));
+			centerPoints.Add(0.75f, new dvec3(0.8f, 1.0f, -1.0f));
+			centerPoints.Add(1.0f, new dvec3(0.6f, -0.5f, -0.9f));
 			
 			SpatialCubicSpline boneCenter = new SpatialCubicSpline(centerPoints);
 			
 			// Add first bone:
-			LineSegment centerLine = new LineSegment(new Numerics.Vector3(0.0f, 0.0f, 0.5f),
-									   new Numerics.Vector3(0.001f, 10.0f, 0.51f));
+			LineSegment centerLine = new LineSegment(new dvec3(0.0f, 0.0f, 0.5f),
+									   new dvec3(0.001f, 10.0f, 0.51f));
 			
 			var bone1 = new Anatomy.Bones.LongBone(centerLine, boneRadius);
 			
@@ -66,8 +64,8 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			skeleton.bones.Add(bone1);
 			
 			// Add second bone:
-			//LineSegment centerLine2 = new LineSegment(new Numerics.Vector3(0.0f, -10.0f, 0.5f),
-			//						   new Numerics.Vector3(0.001f, -1.0f, 0.51f));
+			//LineSegment centerLine2 = new LineSegment(new dvec3(0.0f, -10.0f, 0.5f),
+			//						   new dvec3(0.001f, -1.0f, 0.51f));
 			
 			//var bone2 = new Anatomy.Bones.LongBone(centerLine2, 1.1f);
 			//bone2.InteractingJoints.Add((skeleton.joints[0], RayCastDirection.Outwards, 3.0f));
@@ -94,8 +92,8 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 		public void CreateExampleJoint(Anatomy.Skeleton skeleton)
 		{
 			// Generate a simple cubic spline that will act as the radius of a long bone:
-			SortedList<float, float> splinePoints = new SortedList<float, float>();
-			float radiusModifier = 0.6f;
+			SortedList<double, double> splinePoints = new SortedList<double, double>();
+			double radiusModifier = 0.6f;
 			splinePoints.Add(-0.1f, radiusModifier*1.1f);
 			splinePoints.Add(0.0f, radiusModifier*1.1f);
 			splinePoints.Add(0.15f, radiusModifier*0.95f);
@@ -108,11 +106,11 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			QuadraticSpline1D jointSpline = new QuadraticSpline1D(splinePoints);
 
 			// Define the center curve of the long bone:
-			LineSegment centerLine = new LineSegment(new Numerics.Vector3(0.0f, -0.5f, 0.0f),
-									   new Numerics.Vector3(0.0f, 1.5f, 0.5f));
+			LineSegment centerLine = new LineSegment(new dvec3(0.0f, -0.5f, 0.0f),
+									   new dvec3(0.0f, 1.5f, 0.5f));
 			
 			// Add a long bone to the character:
-			skeleton.joints.Add(new Anatomy.Joints.HingeJoint(centerLine, jointSpline, 0.0f, 1.0f*(float)Math.PI));
+			skeleton.joints.Add(new Anatomy.Joints.HingeJoint(centerLine, jointSpline, 0.0f, 1.0f*(double)Math.PI));
 			
 			// Generate the geometry vertices of the first bone with resolution U=32 and resolution V=32:
 			UVMesh mesh = skeleton.joints[0].GetArticularSurface().GenerateMesh(64, 64);

--- a/gui/GodotMeshConverter.cs
+++ b/gui/GodotMeshConverter.cs
@@ -1,10 +1,6 @@
 using Godot;
-using System;
-using System.Collections.Generic;
-using Numerics = System.Numerics;
+using GlmSharp;
 
-using FreedomOfFormFoundation.AnatomyEngine.Geometry;
-using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 using FreedomOfFormFoundation.AnatomyEngine.Renderable;
 
 namespace FreedomOfFormFoundation.AnatomyRenderer
@@ -20,16 +16,16 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			
 			int vertexCount = mesh.VertexList.Count;
 			
-			Godot.Vector3[] normal_array = new Godot.Vector3[vertexCount];
-			Godot.Vector3[] vertex_array = new Godot.Vector3[vertexCount];
+			Vector3[] normal_array = new Godot.Vector3[vertexCount];
+			Vector3[] vertex_array = new Godot.Vector3[vertexCount];
 			
 			// Populate the arrays from the input mesh data:
 			for (int i = 0; i < vertexCount; i++)
 			{
-				Numerics.Vector3 vertex = mesh.VertexList[i].Position;
-				Numerics.Vector3 normal = mesh.VertexList[i].Normal;
-				vertex_array[i] = new Godot.Vector3(vertex.X, vertex.Y, vertex.Z);
-				normal_array[i] = new Godot.Vector3(normal.X, normal.Y, normal.Z);
+				vec3 vertex = mesh.VertexList[i].Position;
+				vec3 normal = mesh.VertexList[i].Normal;
+				vertex_array[i] = new Vector3(vertex.x, vertex.y, vertex.z);
+				normal_array[i] = new Vector3(normal.x, normal.y, normal.z);
 			}
 			
 			// The index list doesn't need to be converted:


### PR DESCRIPTION
This PR replaces the matrix-vector math in the engine with GlmSharp as discussed.

These are only refactorings of existing content, and should exhibit the same behavior as before the commit (except with higher precision now). Using GlmSharp, we can use proper matrix-vector mathematics and also use different precision for vector types, such as double.

The tested code appears to work correctly within the visual test. The unit tests all work except for two infinity checks, which may or may not have been broken before already (@AdamNorberg also noticed this before this PR, so I'll ignore it for now and propose we look into it in a different PR).