### PR TITLE
Display bone in editor

### DIFF
--- a/gui/ExampleBone.cs
+++ b/gui/ExampleBone.cs
@@ -12,6 +12,7 @@ using FreedomOfFormFoundation.AnatomyEngine.Renderable;
 
 namespace FreedomOfFormFoundation.AnatomyRenderer
 {
+	[Tool]
 	public class ExampleBone : MeshInstance
 	{
 		// Called when the node enters the scene tree for the first time.


### PR DESCRIPTION
Using `[Tool]`, we can display the bone in the editor. That way, we can possibly utilize the editor's editing capabilities for ourselves.