### PR TITLE
Add debug-only range checks

### DIFF
--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -29,12 +29,16 @@
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
         <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
+        <DefineConstants></DefineConstants>
         <ErrorReport>prompt</ErrorReport>
         <WarningLevel>4</WarningLevel>
+        <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UnitTests|AnyCPU' ">
       <OutputPath>bin\UnitTests\</OutputPath>
+      <DefineConstants>DEBUG;TRACE</DefineConstants>
+      <DebugSymbols>true</DebugSymbols>
+      <DebugType>full</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="System" />

--- a/EngineTests/calculus/QuadraticFunctionTests.cs
+++ b/EngineTests/calculus/QuadraticFunctionTests.cs
@@ -8,101 +8,101 @@ using Xunit.Abstractions;
 
 namespace EngineTests.calculus
 {
-    public class QuadraticFunctionTests
-    {
-        // Utility for associating logged output with a test.
-        private readonly ITestOutputHelper testLogger;
+	public class QuadraticFunctionTests
+	{
+		// Utility for associating logged output with a test.
+		private readonly ITestOutputHelper testLogger;
 
-        public QuadraticFunctionTests(ITestOutputHelper testLogger)
-        {
-            this.testLogger = testLogger;
-        }
+		public QuadraticFunctionTests(ITestOutputHelper testLogger)
+		{
+			this.testLogger = testLogger;
+		}
 
-        /// <summary>
-        /// Tests quadratic function evaluation in cases where the expected value is a number. This test passes if the
-        /// actual result is relatively near the expected result.
-        /// </summary>
-        /// <param name="a0">Constant term in quadratic function.</param>
-        /// <param name="a1">Linear term in quadratic function.</param>
-        /// <param name="a2">Quadratic term in quadratic function.</param>
-        /// <param name="x">Value to test at.</param>
-        /// <param name="expected"></param>
-        [Theory]
-        [InlineData(0, 0, 0, 0, 0)]
-        [InlineData(1000, 0, 0, 0, 1000)]
-        [InlineData(1000, 0, 0, 87429, 1000)]
-        [InlineData(0, 1, 0, 0, 0)]
-        [InlineData(0, 1, 0, 3.14159, 3.14159)]
-        [InlineData(0, 1e10, 0, 1e5, 1e15)]
-        [InlineData(42, 20, 0, 10, 242)]
-        public void TestValueCalculation(double a0, double a1, double a2, double x, double expected)
-        {
-            QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
-            Assert.NotNull(q);
-            Assert.Equal(expected, q.GetValueAt(x), 6);
-            Assert.Equal(expected, q.GetNthDerivativeAt(x, 0), 6);
-        }
+		/// <summary>
+		/// Tests quadratic function evaluation in cases where the expected value is a number. This test passes if the
+		/// actual result is relatively near the expected result.
+		/// </summary>
+		/// <param name="a0">Constant term in quadratic function.</param>
+		/// <param name="a1">Linear term in quadratic function.</param>
+		/// <param name="a2">Quadratic term in quadratic function.</param>
+		/// <param name="x">Value to test at.</param>
+		/// <param name="expected"></param>
+		[Theory]
+		[InlineData(0, 0, 0, 0, 0)]
+		[InlineData(1000, 0, 0, 0, 1000)]
+		[InlineData(1000, 0, 0, 87429, 1000)]
+		[InlineData(0, 1, 0, 0, 0)]
+		[InlineData(0, 1, 0, 3.14159, 3.14159)]
+		[InlineData(0, 1e10, 0, 1e5, 1e15)]
+		[InlineData(42, 20, 0, 10, 242)]
+		public void TestValueCalculation(double a0, double a1, double a2, double x, double expected)
+		{
+			QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
+			Assert.NotNull(q);
+			Assert.Equal(expected, q.GetValueAt(x), 6);
+			Assert.Equal(expected, q.GetNthDerivativeAt(x, 0), 6);
+		}
 
-        /// <summary>
-        /// Tests evaluation of a function at derivatives from 0 to 4. Does not support expected
-        /// NaN results. The 3rd and 4th derivatives of a quadratic function are always 0, so
-        /// there is no parameter for this.
-        /// </summary>
-        /// <param name="a0">Constant term in the quadratic function.</param>
-        /// <param name="a1">Linear term in the quadratic function.</param>
-        /// <param name="a2">Quadratic term in the quadratic function.</param>
-        /// <param name="x">Value of Location to test at.</param>
-        /// <param name="atD0">Expected value of the function (the 0th derivative) at x.</param>
-        /// <param name="atD1">Expected value of the first derivative at x.</param>
-        /// <param name="atD2">Expected value of the second derivative at x.</param>
-        [Theory]
-        [InlineData(0, 0, 0, 0, 0, 0, 0)]
-        [InlineData(1, 0, 0, 20, 1, 0, 0)]
-        [InlineData(1, 2, 0, 10, 21, 2, 0)]
-        [InlineData(1, 2, 4, 2, 21, 18, 8)]
-        public void TestDerivativesAt(double a0, double a1, double a2, double x, double atD0, double atD1, double atD2)
-        {
-            QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
-            Assert.NotNull(q);
-            Assert.Equal(q.GetNthDerivativeAt(x, 0), atD0, 6);
-            Assert.Equal(q.GetNthDerivativeAt(x, 1), atD1, 6);
-            Assert.Equal(q.GetDerivativeAt(x), atD1, 6);
-            Assert.Equal(q.GetNthDerivativeAt(x, 2), atD2, 6);
-            Assert.Equal(q.GetNthDerivativeAt(x, 3), 0);
-            Assert.Equal(q.GetNthDerivativeAt(x, 4), 0);
-        }
+		/// <summary>
+		/// Tests evaluation of a function at derivatives from 0 to 4. Does not support expected
+		/// NaN results. The 3rd and 4th derivatives of a quadratic function are always 0, so
+		/// there is no parameter for this.
+		/// </summary>
+		/// <param name="a0">Constant term in the quadratic function.</param>
+		/// <param name="a1">Linear term in the quadratic function.</param>
+		/// <param name="a2">Quadratic term in the quadratic function.</param>
+		/// <param name="x">Value of Location to test at.</param>
+		/// <param name="atD0">Expected value of the function (the 0th derivative) at x.</param>
+		/// <param name="atD1">Expected value of the first derivative at x.</param>
+		/// <param name="atD2">Expected value of the second derivative at x.</param>
+		[Theory]
+		[InlineData(0, 0, 0, 0, 0, 0, 0)]
+		[InlineData(1, 0, 0, 20, 1, 0, 0)]
+		[InlineData(1, 2, 0, 10, 21, 2, 0)]
+		[InlineData(1, 2, 4, 2, 21, 18, 8)]
+		public void TestDerivativesAt(double a0, double a1, double a2, double x, double atD0, double atD1, double atD2)
+		{
+			QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
+			Assert.NotNull(q);
+			Assert.Equal(q.GetNthDerivativeAt(x, 0), atD0, 6);
+			Assert.Equal(q.GetNthDerivativeAt(x, 1), atD1, 6);
+			Assert.Equal(q.GetDerivativeAt(x), atD1, 6);
+			Assert.Equal(q.GetNthDerivativeAt(x, 2), atD2, 6);
+			Assert.Equal(q.GetNthDerivativeAt(x, 3), 0);
+			Assert.Equal(q.GetNthDerivativeAt(x, 4), 0);
+		}
 
 
-        [Theory]
-        [InlineData(0, 1, 1, new double[]{-1, 0})]
-        public void TestSolve(double a0, double a1, double a2, double[] want)
-        {
-            IList<double> got = QuadraticFunction.Solve(a0, a1, a2).ToList();
-            Assert.Equal(want.Length, got.Count);
-            // There are no guarantees as to the order of values returned, so sort both sequences and compare items
-            // at equal locations in the sorted sequence. Expect them all to match. We don't need to try any other
-            // permutations of these lists to find out if there's some way they do match:
-            //
-            // If the smallest unmatched elements of each set are not adequately near each other, there is no way to
-            // match the smaller of the two to any element in its other set. We have just compared it against the
-            // smallest element in the other set, and found it to be too large. It cannot be too small, because we
-            // are specifically considering the smaller element of the mismatched pair. Since the too-large element
-            // was a smallest element of its set, all other elements are at least that large. Therefore, there is no
-            // element small enough to match the smallest unmatched element between both sets, so the sets are unequal.
-            // Backtracking does not help, because to find a smaller element of the opposite set, we must take it away
-            // from its match to an element that is no larger than the one we are now matching (because all larger
-            // elements are still in the unmatched portion of the set), and now _that_ element has the same problem
-            // but worse.
-            //
-            // Therefore, there is no reason to attempt any other order than an element-by-element pairwise comparison
-            // of the sorted sequences. ∎
-            Array.Sort(want);
-            int i = 0;
-            var gotSorted = from c in got orderby c select c;
-            foreach(double f in gotSorted)
-            {
-                Assert.Equal(want[i++], f, 6);
-            }
-        }
-    }
+		[Theory]
+		[InlineData(0, 1, 1, new double[] { -1, 0 })]
+		public void TestSolve(double a0, double a1, double a2, double[] want)
+		{
+			IList<double> got = QuadraticFunction.Solve(a0, a1, a2).ToList();
+			Assert.Equal(want.Length, got.Count);
+			// There are no guarantees as to the order of values returned, so sort both sequences and compare items
+			// at equal locations in the sorted sequence. Expect them all to match. We don't need to try any other
+			// permutations of these lists to find out if there's some way they do match:
+			//
+			// If the smallest unmatched elements of each set are not adequately near each other, there is no way to
+			// match the smaller of the two to any element in its other set. We have just compared it against the
+			// smallest element in the other set, and found it to be too large. It cannot be too small, because we
+			// are specifically considering the smaller element of the mismatched pair. Since the too-large element
+			// was a smallest element of its set, all other elements are at least that large. Therefore, there is no
+			// element small enough to match the smallest unmatched element between both sets, so the sets are unequal.
+			// Backtracking does not help, because to find a smaller element of the opposite set, we must take it away
+			// from its match to an element that is no larger than the one we are now matching (because all larger
+			// elements are still in the unmatched portion of the set), and now _that_ element has the same problem
+			// but worse.
+			//
+			// Therefore, there is no reason to attempt any other order than an element-by-element pairwise comparison
+			// of the sorted sequences. ∎
+			Array.Sort(want);
+			int i = 0;
+			var gotSorted = from c in got orderby c select c;
+			foreach (double f in gotSorted)
+			{
+				Assert.Equal(want[i++], f, 6);
+			}
+		}
+	}
 }

--- a/EngineTests/calculus/QuadraticFunctionTests.cs
+++ b/EngineTests/calculus/QuadraticFunctionTests.cs
@@ -28,43 +28,19 @@ namespace EngineTests.calculus
         /// <param name="x">Value to test at.</param>
         /// <param name="expected"></param>
         [Theory]
-        [InlineData(0f, 0f, 0f, 0f, 0f)]
-        [InlineData(1000f, 0f, 0f, 0f, 1000f)]
-        [InlineData(1000f, 0f, 0f, 87429f, 1000f)]
-        [InlineData(0f, 1f, 0f, 0f, 0f)]
-        [InlineData(0f, 1f, 0f, 3.14159f, 3.14159f)]
-        [InlineData(0f, 1e10f, 0f, 1e5f, 1e15f)]
-        [InlineData(42f, 20f, 0f, 10f, 242f)]
-        [InlineData(float.NegativeInfinity, 1f, 0f, 10f, float.NegativeInfinity)]
-        [InlineData(float.PositiveInfinity, 1e-15f, 0f, float.PositiveInfinity, float.PositiveInfinity)]
-        [InlineData(1000f, 0f, 0f, float.NegativeInfinity, float.NegativeInfinity)]
-        public void TestValueCalculation(float a0, float a1, float a2, float x, float expected)
+        [InlineData(0, 0, 0, 0, 0)]
+        [InlineData(1000, 0, 0, 0, 1000)]
+        [InlineData(1000, 0, 0, 87429, 1000)]
+        [InlineData(0, 1, 0, 0, 0)]
+        [InlineData(0, 1, 0, 3.14159, 3.14159)]
+        [InlineData(0, 1e10, 0, 1e5, 1e15)]
+        [InlineData(42, 20, 0, 10, 242)]
+        public void TestValueCalculation(double a0, double a1, double a2, double x, double expected)
         {
             QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
             Assert.NotNull(q);
             Assert.Equal(expected, q.GetValueAt(x), 6);
             Assert.Equal(expected, q.GetNthDerivativeAt(x, 0), 6);
-        }
-
-        /// <summary>
-        /// Tests quadratic function evaluation in cases where the expected value is NaN, which
-        /// requires special comparison.
-        ///
-        /// Note that, in IEEE floating point, 0 is "zero-ish", so multiplying infinity by a zero is numerically
-        /// undefined, represented as NaN. Cases multiplying infinity by zero wind up here.
-        /// </summary>
-        /// <param name="a0">Constant term in quadratic function.</param>
-        /// <param name="a1">Linear term in quadratic function.</param>
-        /// <param name="a2">Quadratic term in quadratic function.</param>
-        /// <param name="x">Value to test at.</param>
-        [Theory]
-        [InlineData(float.PositiveInfinity, 1e-15f, 0f, float.NegativeInfinity)]
-        public void TestValueNaN(float a0, float a1, float a2, float x)
-        {
-            QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
-            Assert.NotNull(q);
-            Assert.True(float.IsNaN(q.GetValueAt(x)));
-            Assert.True(float.IsNaN(q.GetNthDerivativeAt(x, 0)));
         }
 
         /// <summary>
@@ -80,11 +56,11 @@ namespace EngineTests.calculus
         /// <param name="atD1">Expected value of the first derivative at x.</param>
         /// <param name="atD2">Expected value of the second derivative at x.</param>
         [Theory]
-        [InlineData(0f,0f,0f,0f,0f,0f,0f)]
-        [InlineData(1f, 0f, 0f, 20f, 1f, 0f, 0f)]
-        [InlineData(1f, 2f, 0f, 10f, 21f, 2f, 0f)]
-        [InlineData(1f, 2f, 4f, 2f, 21f, 18f, 8f)]
-        public void TestDerivativesAt(float a0, float a1, float a2, float x, float atD0, float atD1, float atD2)
+        [InlineData(0, 0, 0, 0, 0, 0, 0)]
+        [InlineData(1, 0, 0, 20, 1, 0, 0)]
+        [InlineData(1, 2, 0, 10, 21, 2, 0)]
+        [InlineData(1, 2, 4, 2, 21, 18, 8)]
+        public void TestDerivativesAt(double a0, double a1, double a2, double x, double atD0, double atD1, double atD2)
         {
             QuadraticFunction q = new QuadraticFunction(a0, a1, a2);
             Assert.NotNull(q);
@@ -98,10 +74,10 @@ namespace EngineTests.calculus
 
 
         [Theory]
-        [InlineData(0f, 1f, 1f, new float[]{-1f, 0f})]
-        public void TestSolve(float a0, float a1, float a2, float[] want)
+        [InlineData(0, 1, 1, new double[]{-1, 0})]
+        public void TestSolve(double a0, double a1, double a2, double[] want)
         {
-            IList<float> got = QuadraticFunction.Solve(a0, a1, a2).ToList();
+            IList<double> got = QuadraticFunction.Solve(a0, a1, a2).ToList();
             Assert.Equal(want.Length, got.Count);
             // There are no guarantees as to the order of values returned, so sort both sequences and compare items
             // at equal locations in the sorted sequence. Expect them all to match. We don't need to try any other
@@ -123,7 +99,7 @@ namespace EngineTests.calculus
             Array.Sort(want);
             int i = 0;
             var gotSorted = from c in got orderby c select c;
-            foreach(float f in gotSorted)
+            foreach(double f in gotSorted)
             {
                 Assert.Equal(want[i++], f, 6);
             }

--- a/engine/calculus/CubicFunction.cs
+++ b/engine/calculus/CubicFunction.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System;
+using System.Security.Cryptography;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -44,6 +45,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		
 		public double GetNthDerivativeAt(double x, uint derivative)
 		{
+			DebugUtil.AssertFinite(x, nameof(x));
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
@@ -77,6 +79,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		public static IEnumerable<double> Solve(double d, double c, double b, double a)
 		{
+			DebugUtil.AssertFinite(a, nameof(a));
+			DebugUtil.AssertFinite(b, nameof(b));
+			DebugUtil.AssertFinite(c, nameof(c));
+			DebugUtil.AssertFinite(d, nameof(d));
 			if(Math.Abs(a) <= 0.005f)
 			{
 				foreach (double v in QuadraticFunction.Solve(d, c, b))
@@ -110,6 +116,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			{
 				if(Math.Abs(root.Imaginary) <= 0.05)
 				{
+					DebugUtil.AssertFinite(root.Real, nameof(root.Real));
 					yield return root.Real;
 				}
 			}

--- a/engine/calculus/CubicSpline1D.cs
+++ b/engine/calculus/CubicSpline1D.cs
@@ -135,11 +135,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </exception>
 		public double GetNthDerivativeAt(double x, uint derivative)
 		{
-			DebugUtil.AssertFinite(x, nameof(x));
 			// The input parameter must lie between the outer points, and must not be NaN:
 			if (!( x >= Points.Key[0] && x <= Points.Key[Points.Count - 1]))
 			{
-				throw new ArgumentOutOfRangeException(nameof(x), "Cannot interpolate outside the interval given by the spline points.");
+				throw new ArgumentOutOfRangeException(nameof(x), $"Cannot interpolate at {x}, which is outside the interval given by the spline points.");
 			}
 			
 			// Find the index `i` of the closest point to the right of the input `x` parameter, which is the right point

--- a/engine/calculus/CubicSpline1D.cs
+++ b/engine/calculus/CubicSpline1D.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -67,6 +68,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			}
 			
 			Points = new SortedPointsList<double>(points);
+			DebugUtil.AssertAllFinite(Points, nameof(Points));
 			
 			// Calculate the coefficients of the spline:
 			double[] a = new double[points.Count];
@@ -133,6 +135,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </exception>
 		public double GetNthDerivativeAt(double x, uint derivative)
 		{
+			DebugUtil.AssertFinite(x, nameof(x));
 			// The input parameter must lie between the outer points, and must not be NaN:
 			if (!( x >= Points.Key[0] && x <= Points.Key[Points.Count - 1]))
 			{
@@ -210,6 +213,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		private static double[] ThomasAlgorithm(double[] a, double[] b, double[] c, double[] d)
 		{
+			DebugUtil.AssertAllFinite(a, nameof(a));
+			DebugUtil.AssertAllFinite(b, nameof(b));
+			DebugUtil.AssertAllFinite(c, nameof(c));
+			DebugUtil.AssertAllFinite(d, nameof(d));
+
 			int size = d.Count();
 			
 			// Perform forward sweep:
@@ -223,6 +231,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				newC[i] = c[i] / ( b[i] - a[i]*newC[i-1] );
 				newD[i] = (d[i] - a[i]*newD[i-1]) / ( b[i] - a[i]*newC[i-1] );
 			}
+			DebugUtil.AssertAllFinite(newC, nameof(newC));
+			DebugUtil.AssertAllFinite(newD, nameof(newD));
 			
 			// Perform back substitution:
 			double[] x = new double[size];
@@ -232,7 +242,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			{
 				x[i] = newD[i] - newC[i]*x[i+1];
 			}
-			
+
+			DebugUtil.AssertAllFinite(x, nameof(x));
 			return x;
 		}
 	}

--- a/engine/calculus/LinearSpline1D.cs
+++ b/engine/calculus/LinearSpline1D.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System;
+using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -64,6 +65,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			}
 			
 			Points = new SortedPointsList<double>(points);
+			DebugUtil.AssertAllFinite(Points, nameof(Points));
 
 			// Calculate the coefficients for each segment of the spline:
 			_parameters = new double[points.Count];
@@ -76,6 +78,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 
 				_parameters[i] = dy / dx;
 			}
+			DebugUtil.AssertAllFinite(_parameters, nameof(_parameters));
 		}
 
 		/// <summary>
@@ -99,7 +102,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			// The input parameter must lie between the outer points, and must not be NaN:
 			if (!( x >= Points.Key[0] && x <= Points.Key[Points.Count - 1]))
 			{
-				throw new ArgumentOutOfRangeException(nameof(x), "Cannot interpolate outside the interval given by the spline points.");
+				throw new ArgumentOutOfRangeException(nameof(x), $"Cannot interpolate at {x}, which is outside the interval given by the spline points.");
 			}
 			
 			// Find the index `i` of the closest point to the right of the input `x` parameter, which is the right point
@@ -139,8 +142,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			// Return the result of evaluating a derivative function, depending on the derivative level:
 			switch (derivative)
 			{
-				case 0: return global_y;
-				case 1: return slope;
+				case 0:
+					DebugUtil.AssertFinite(global_y, nameof(global_y));
+					return global_y;
+				case 1:
+					DebugUtil.AssertFinite(slope, nameof(slope));
+					return slope;
 				default: return 0.0;
 			}
 		}

--- a/engine/calculus/MoldCastMap.cs
+++ b/engine/calculus/MoldCastMap.cs
@@ -138,6 +138,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <inheritdoc />
 		public override double GetValueAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			double directionSign = (direction == RayCastDirection.Outwards) ? 1.0 : -1.0;
 
 			Ray ray = new Ray(raycastSurface.GetPositionAt(uv), directionSign*raycastSurface.GetNormalAt(uv).Normalized);

--- a/engine/calculus/QuadraticFunction.cs
+++ b/engine/calculus/QuadraticFunction.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System;
+using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -33,6 +34,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		public QuadraticFunction(double a0, double a1, double a2)
 		{
+			DebugUtil.AssertFinite(a0, nameof(a0));
+			DebugUtil.AssertFinite(a1, nameof(a1));
+			DebugUtil.AssertFinite(a2, nameof(a2));
 			_a0 = a0;
 			_a1 = a1;
 			_a2 = a2;
@@ -40,6 +44,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		
 		public double GetNthDerivativeAt(double x, uint derivative)
 		{
+			DebugUtil.AssertFinite(x, nameof(x));
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
@@ -77,6 +82,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		public static IEnumerable<double> Solve(double a0, double a1, double a2)
 		{
+			DebugUtil.AssertFinite(a0, nameof(a0));
+			DebugUtil.AssertFinite(a1, nameof(a1));
+			DebugUtil.AssertFinite(a2, nameof(a2));
 			if(Math.Abs(a2) <= 0.005)
 			{
 				if(Math.Abs(a1) <= 0.005)

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -82,40 +82,40 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		}
 		
 		/// <summary>
-		///     Solves the equation \f$c0 + c1 x + c2 x^2 + c3 x^3 + c4 x^4 = 0\f$, returning all real values of
+		///     Solves the equation \f$a0 + a1 x + a2 x^2 + a3 x^3 + a4 x^4 = 0\f$, returning all real values of
 		///		\f$x\f$ for which the equation is true. See https://en.wikipedia.org/wiki/Quartic_function for the
 		///		algorithm used.
 		/// </summary>
-		public static IEnumerable<double> Solve(double c0, double c1, double c2, double c3, double c4)
+		public static IEnumerable<double> Solve(double a0, double a1, double a2, double a3, double a4)
 		{
-			DebugUtil.AssertAllFinite(new double[]{c0, c1, c2, c3, c4}, "c");
-			if(Math.Abs(c4) <= 0.005)
+			DebugUtil.AssertAllFinite(new double[]{a0, a1, a2, a3, a4}, "a");
+			if(Math.Abs(a4) <= 0.005)
 			{
-				foreach (double v in CubicFunction.Solve(c0, c1, c2, c3))
+				foreach (double v in CubicFunction.Solve(a0, a1, a2, a3))
 				{
 					yield return v;
 				}
 				yield break;
 			}
 
-			double ba = c3/c4;
-			double ca = c2/c4;
-			double da = c1/c4;
-			// double ea = c0/c4;
+			double ba = a3/a4;
+			double ca = a2/a4;
+			double da = a1/a4;
+			// double ea = a0/a4;
 			
-			double p1 = c2*c2*c2 - 4.5*c3*c2*c1 + 13.5*c4*c1*c1 + 13.5*c3*c3*c0 - 36.0*c4*c2*c0;
+			double p1 = a2*a2*a2 - 4.5*a3*a2*a1 + 13.5*a4*a1*a1 + 13.5*a3*a3*a0 - 36.0*a4*a2*a0;
 			
-			double q = c2*c2 - 3.0*c3*c1 + 12.0*c4*c0;
+			double q = a2*a2 - 3.0*a3*a1 + 12.0*a4*a0;
 			
 			Complex p2 = p1 + Complex.Sqrt(-q*q*q + p1*p1);
 			
 			Complex pow = Complex.Pow(p2, (1.0/3.0));
 			
-			Complex p3 = q/(3.0*c4*pow) + pow/(3.0*c4);
+			Complex p3 = q/(3.0*a4*pow) + pow/(3.0*a4);
 			
 			Complex p4 = Complex.Sqrt(ba*ba/4.0 - 2.0*ca/(3.0) + p3);
 			
-			Complex p5 = c3*c3/(2.0*c4*c4) - 4.0*c2/(3.0*c4) - p3;
+			Complex p5 = a3*a3/(2.0*a4*a4) - 4.0*a2/(3.0*a4) - p3;
 			
 			Complex p6 = (-ba*ba*ba + 4.0*ba*ca - 8.0*da)/(4.0*p4);
 			

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -42,7 +42,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		public QuarticFunction(double a0, double a1, double a2, double a3, double a4)
 		{
-
+			DebugUtil.AssertAllFinite(new double[]{a0, a1, a2, a3, a4}, "a");
 			this.a0 = a0;
 			this.a1 = a1;
 			this.a2 = a2;
@@ -52,6 +52,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		
 		public double GetNthDerivativeAt(double x, uint derivative)
 		{
+			DebugUtil.AssertFinite(x, nameof(x));
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
@@ -81,45 +82,40 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		}
 		
 		/// <summary>
-		///     Solves the equation \f$e + d x + c x^2 + b x^3 + a x^4 = 0\f$, returning all real values of
+		///     Solves the equation \f$c0 + c1 x + c2 x^2 + c3 x^3 + c4 x^4 = 0\f$, returning all real values of
 		///		\f$x\f$ for which the equation is true. See https://en.wikipedia.org/wiki/Quartic_function for the
 		///		algorithm used.
 		/// </summary>
-		public static IEnumerable<double> Solve(double e2, double d2, double c2, double b2, double a2)
+		public static IEnumerable<double> Solve(double c0, double c1, double c2, double c3, double c4)
 		{
-			if(Math.Abs(a2) <= 0.005)
+			DebugUtil.AssertAllFinite(new double[]{c0, c1, c2, c3, c4}, "c");
+			if(Math.Abs(c4) <= 0.005)
 			{
-				foreach (double v in CubicFunction.Solve(e2, d2, c2, b2))
+				foreach (double v in CubicFunction.Solve(c0, c1, c2, c3))
 				{
 					yield return v;
 				}
 				yield break;
 			}
+
+			double ba = c3/c4;
+			double ca = c2/c4;
+			double da = c1/c4;
+			// double ea = c0/c4;
 			
-			double a = a2;
-			double b = b2;
-			double c = c2;
-			double d = d2;
-			double e = e2;
+			double p1 = c2*c2*c2 - 4.5*c3*c2*c1 + 13.5*c4*c1*c1 + 13.5*c3*c3*c0 - 36.0*c4*c2*c0;
 			
-			double ba = b/a;
-			double ca = c/a;
-			double da = d/a;
-			double ea = e/a;
-			
-			double p1 = c*c*c - 4.5*b*c*d + 13.5*a*d*d + 13.5*b*b*e - 36.0*a*c*e;
-			
-			double q = c*c - 3.0*b*d + 12.0*a*e;
+			double q = c2*c2 - 3.0*c3*c1 + 12.0*c4*c0;
 			
 			Complex p2 = p1 + Complex.Sqrt(-q*q*q + p1*p1);
 			
 			Complex pow = Complex.Pow(p2, (1.0/3.0));
 			
-			Complex p3 = q/(3.0*a*pow) + pow/(3.0*a);
+			Complex p3 = q/(3.0*c4*pow) + pow/(3.0*c4);
 			
 			Complex p4 = Complex.Sqrt(ba*ba/4.0 - 2.0*ca/(3.0) + p3);
 			
-			Complex p5 = b*b/(2.0*a*a) - 4.0*c/(3.0*a) - p3;
+			Complex p5 = c3*c3/(2.0*c4*c4) - 4.0*c2/(3.0*c4) - p3;
 			
 			Complex p6 = (-ba*ba*ba + 4.0*ba*ca - 8.0*da)/(4.0*p4);
 			
@@ -135,6 +131,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			{
 				if(Math.Abs(root.Imaginary) <= 0.005)
 				{
+					DebugUtil.AssertFinite(root.Real, nameof(root.Real));
 					yield return root.Real;
 				}
 			}

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -17,6 +17,9 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System;
+using System.Configuration;
+using System.Diagnostics;
+using System.Text;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -39,6 +42,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </summary>
 		public QuarticFunction(double a0, double a1, double a2, double a3, double a4)
 		{
+
 			this.a0 = a0;
 			this.a1 = a1;
 			this.a2 = a2;

--- a/engine/calculus/ShiftedMap2D.cs
+++ b/engine/calculus/ShiftedMap2D.cs
@@ -68,6 +68,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </param>
 		public ShiftedMap2D(dvec2 shift, dvec2 stretch, ContinuousMap<dvec2, TOut> function)
 		{
+			DebugUtil.AssertAllFinite(shift, nameof(shift));
+			DebugUtil.AssertAllFinite(stretch, nameof(stretch));
 			this.Shift = shift;
 			this.Stretch = stretch;
 			this.Function = function;
@@ -76,6 +78,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <inheritdoc />
 		public override TOut GetValueAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			return Function.GetValueAt(Shift + Stretch * uv);
 		}
 	}

--- a/engine/engine.csproj
+++ b/engine/engine.csproj
@@ -4,6 +4,29 @@
     <Configurations>Debug;ExportDebug;ExportRelease;UnitTests</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ExportDebug' ">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ExportRelease' ">
+    <DefineConstants />
+    <Optimize>true</Optimize>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'UnitTests' ">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GlmSharp" Version="0.9.8" />
   </ItemGroup>

--- a/engine/geometry/Capsule.cs
+++ b/engine/geometry/Capsule.cs
@@ -97,6 +97,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <inheritdoc />
 		public override dvec3 GetNormalAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			double u = uv.x;
 			double v = uv.y;
 
@@ -121,6 +122,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <inheritdoc />
 		public override dvec3 GetPositionAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			double u = uv.x;
 			double v = uv.y;
 			

--- a/engine/geometry/Cylinder.cs
+++ b/engine/geometry/Cylinder.cs
@@ -51,6 +51,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// </param>
 		public Cylinder(Curve centerCurve, double radius)
 		{
+			DebugUtil.AssertFinite(radius, nameof(radius));
 			this.CenterCurve = centerCurve;
 			this.Radius = new ConstantFunction<dvec2, double>(radius);
 			this.StartAngle = 0.0;
@@ -183,6 +184,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <inheritdoc />
 		public override dvec3 GetNormalAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			double u = uv.x;
 			double v = uv.y;
 			
@@ -199,6 +201,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <inheritdoc />
 		public override dvec3 GetPositionAt(dvec2 uv)
 		{
+			DebugUtil.AssertAllFinite(uv, nameof(uv));
 			double v = uv.y;
 				
 			dvec3 translation = CenterCurve.GetPositionAt(v);
@@ -210,6 +213,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// <inheritdoc />
 		public override List<Vertex> GenerateVertexList(int resolutionU, int resolutionV)
 		{
+			// If asked to sample at zero points, return an empty list.
+			if (resolutionU <= 0 || resolutionV <= 0)
+			{
+				return new List<Vertex>();
+			}
 			var roughs = ParallelEnumerable.Range(0, resolutionV + 1).AsOrdered().SelectMany((j =>
 			{
 				double v = (double) j / (double) resolutionV;

--- a/engine/geometry/Hemisphere.cs
+++ b/engine/geometry/Hemisphere.cs
@@ -77,6 +77,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// </param>
 		public Hemisphere(ContinuousMap<dvec2, double> radius, dvec3 center, dvec3 direction, dvec3 normal, dvec3 binormal)
 		{
+			DebugUtil.AssertAllFinite(center, nameof(center));
+			DebugUtil.AssertAllFinite(direction, nameof(direction));
+			DebugUtil.AssertAllFinite(normal, nameof(normal));
+			DebugUtil.AssertAllFinite(binormal, nameof(binormal));
 			this.Radius = radius;
 			this.Center = center;
 			this.Direction = direction;

--- a/engine/geometry/SymmetricCylinder.cs
+++ b/engine/geometry/SymmetricCylinder.cs
@@ -126,17 +126,25 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		{
 			dvec3 rayStart = ray.StartPosition;
 			dvec3 rayDirection = ray.Direction;
+			DebugUtil.AssertAllFinite(rayStart, nameof(rayStart));
+			DebugUtil.AssertAllFinite(rayDirection, nameof(rayDirection));
 			
 			// Since we raytrace only using a cylindrical surface that is horizontal and at the origin, we
 			// first shift and rotate the ray such that we get the right orientation:
 			dvec3 start = CenterCurve.GetStartPosition();
 			dvec3 end = CenterCurve.GetEndPosition();
+			DebugUtil.AssertAllFinite(start, nameof(start));
+			DebugUtil.AssertAllFinite(end, nameof(end));
 			
 			dvec3 tangent = CenterCurve.GetTangentAt(0.0).Normalized;
 			dvec3 normal = CenterCurve.GetNormalAt(0.0).Normalized;
 			dvec3 binormal = CenterCurve.GetBinormalAt(0.0).Normalized;
+			DebugUtil.AssertAllFinite(tangent, nameof(tangent));
+			DebugUtil.AssertAllFinite(normal, nameof(normal));
+			DebugUtil.AssertAllFinite(binormal, nameof(binormal));
 			
 			double length = dvec3.Distance(start, end);
+			DebugUtil.AssertFinite(length, nameof(length));
 			
 			// CenterCurve is guaranteed to be a LineSegment, since the base property CenterCurve is masked by this
 			// class' CenterCurve property that only accepts a LineSegment, and similarly this class' constructor only

--- a/engine/utilities/DebugUtil.cs
+++ b/engine/utilities/DebugUtil.cs
@@ -14,7 +14,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
@@ -33,7 +35,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine
         /// </summary>
         /// <param name="x">Value to range check.</param>
         /// <param name="varName">Name of variable being checked (use nameof); included in error message. </param>
-        [System.Diagnostics.Conditional("DEBUG")]
+        [Conditional("DEBUG")]
         public static void AssertFinite(double x, string varName)
         {
             Debug.Assert(
@@ -41,6 +43,36 @@ namespace FreedomOfFormFoundation.AnatomyEngine
                 "Transfinite double error",
                 "Variable {0}, expected to be finite, had illegal value {1}.",
                 varName, x);
+        }
+
+        /// <summary>
+        /// AssertAllFinite crashes the program (in debug mode) if any item in items is infinite or NaN.
+        /// It does not object to negative zero.
+        /// </summary>
+        /// <param name="items">Collection of items to range check.</param>
+        /// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
+        [Conditional("DEBUG")]
+        public static void AssertAllFinite(IEnumerable<double> items, string varName)
+        {
+            uint idx = 0;
+            foreach (double item in items)
+            {
+                AssertFinite(item, $"{varName}[{idx}]");
+                idx++;
+            }
+        }
+
+        /// <summary>
+        /// AssertAllFinite crashes the program (in debug mode) if any element of any point in the SortedPointsList
+        /// is infinite or NaN. It does not object to negative zero.
+        /// </summary>
+        /// <param name="items">Collection of items to range check.</param>
+        /// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
+        [Conditional("DEBUG")]
+        public static void AssertAllFinite(SortedPointsList<double> items, string varName)
+        {
+            AssertAllFinite(items.Key, $"{varName}.Key");
+            AssertAllFinite(items.Value, $"{varName}.Value");
         }
     }
 }

--- a/engine/utilities/DebugUtil.cs
+++ b/engine/utilities/DebugUtil.cs
@@ -20,59 +20,59 @@ using FreedomOfFormFoundation.AnatomyEngine.Calculus;
 
 namespace FreedomOfFormFoundation.AnatomyEngine
 {
-    /// <summary>
-    /// DebugUtil contains assorted <c>void</c> methods that are not compiled
-    /// into release builds. They contain various assertions and checks for
-    /// potential bugs that should be detected as close as possible to where
-    /// they arise, but the performance impact of these checks would be
-    /// inappropriate in a release build.
-    /// </summary>
-    public static class DebugUtil
-    {
-        /// <summary>
-        /// AssertFinite crashes the program (in debug mode) if <c>x</c> is infinite or NaN.
-        /// It does not object to negative zero.
-        /// </summary>
-        /// <param name="x">Value to range check.</param>
-        /// <param name="varName">Name of variable being checked (use nameof); included in error message. </param>
-        [Conditional("DEBUG")]
-        public static void AssertFinite(double x, string varName)
-        {
-            Debug.Assert(
-                !double.IsInfinity(x) && !double.IsNaN(x),
-                "Transfinite double error",
-                "Variable {0}, expected to be finite, had illegal value {1}.",
-                varName, x);
-        }
+	/// <summary>
+	/// DebugUtil contains assorted <c>void</c> methods that are not compiled
+	/// into release builds. They contain various assertions and checks for
+	/// potential bugs that should be detected as close as possible to where
+	/// they arise, but the performance impact of these checks would be
+	/// inappropriate in a release build.
+	/// </summary>
+	public static class DebugUtil
+	{
+		/// <summary>
+		/// AssertFinite crashes the program (in debug mode) if <c>x</c> is infinite or NaN.
+		/// It does not object to negative zero.
+		/// </summary>
+		/// <param name="x">Value to range check.</param>
+		/// <param name="varName">Name of variable being checked (use nameof); included in error message. </param>
+		[Conditional("DEBUG")]
+		public static void AssertFinite(double x, string varName)
+		{
+			Debug.Assert(
+				!double.IsInfinity(x) && !double.IsNaN(x),
+				"Transfinite double error",
+				"Variable {0}, expected to be finite, had illegal value {1}.",
+				varName, x);
+		}
 
-        /// <summary>
-        /// AssertAllFinite crashes the program (in debug mode) if any item in items is infinite or NaN.
-        /// It does not object to negative zero.
-        /// </summary>
-        /// <param name="items">Collection of items to range check.</param>
-        /// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
-        [Conditional("DEBUG")]
-        public static void AssertAllFinite(IEnumerable<double> items, string varName)
-        {
-            uint idx = 0;
-            foreach (double item in items)
-            {
-                AssertFinite(item, $"{varName}[{idx}]");
-                idx++;
-            }
-        }
+		/// <summary>
+		/// AssertAllFinite crashes the program (in debug mode) if any item in items is infinite or NaN.
+		/// It does not object to negative zero.
+		/// </summary>
+		/// <param name="items">Collection of items to range check.</param>
+		/// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
+		[Conditional("DEBUG")]
+		public static void AssertAllFinite(IEnumerable<double> items, string varName)
+		{
+			uint idx = 0;
+			foreach (double item in items)
+			{
+				AssertFinite(item, $"{varName}[{idx}]");
+				idx++;
+			}
+		}
 
-        /// <summary>
-        /// AssertAllFinite crashes the program (in debug mode) if any element of any point in the SortedPointsList
-        /// is infinite or NaN. It does not object to negative zero.
-        /// </summary>
-        /// <param name="items">Collection of items to range check.</param>
-        /// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
-        [Conditional("DEBUG")]
-        public static void AssertAllFinite(SortedPointsList<double> items, string varName)
-        {
-            AssertAllFinite(items.Key, $"{varName}.Key");
-            AssertAllFinite(items.Value, $"{varName}.Value");
-        }
-    }
+		/// <summary>
+		/// AssertAllFinite crashes the program (in debug mode) if any element of any point in the SortedPointsList
+		/// is infinite or NaN. It does not object to negative zero.
+		/// </summary>
+		/// <param name="items">Collection of items to range check.</param>
+		/// <param name="varName">Name of variable being checked (use nameof); included in error message.</param>
+		[Conditional("DEBUG")]
+		public static void AssertAllFinite(SortedPointsList<double> items, string varName)
+		{
+			AssertAllFinite(items.Key, $"{varName}.Key");
+			AssertAllFinite(items.Value, $"{varName}.Value");
+		}
+	}
 }

--- a/engine/utilities/DebugUtil.cs
+++ b/engine/utilities/DebugUtil.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Copyright (C) 2021 Freedom of Form Foundation, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License, version 2 (GPLv2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License, version 2 (GPLv2) for more details.
+ *
+ * You should have received a copy of the GNU General Public License, version 2 (GPLv2)
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Diagnostics;
+
+namespace FreedomOfFormFoundation.AnatomyEngine
+{
+    /// <summary>
+    /// DebugUtil contains assorted <c>void</c> methods that are not compiled
+    /// into release builds. They contain various assertions and checks for
+    /// potential bugs that should be detected as close as possible to where
+    /// they arise, but the performance impact of these checks would be
+    /// inappropriate in a release build.
+    /// </summary>
+    public static class DebugUtil
+    {
+        /// <summary>
+        /// AssertFinite crashes the program (in debug mode) if <c>x</c> is infinite or NaN.
+        /// It does not object to negative zero.
+        /// </summary>
+        /// <param name="x">Value to range check.</param>
+        /// <param name="varName">Name of variable being checked (use nameof); included in error message. </param>
+        [System.Diagnostics.Conditional("DEBUG")]
+        public static void AssertFinite(double x, string varName)
+        {
+            Debug.Assert(
+                !double.IsInfinity(x) && !double.IsNaN(x),
+                "Transfinite double error",
+                "Variable {0}, expected to be finite, had illegal value {1}.",
+                varName, x);
+        }
+    }
+}

--- a/gui/AnatomyProject.csproj
+++ b/gui/AnatomyProject.csproj
@@ -4,6 +4,25 @@
     <Configurations>Debug;ExportDebug;ExportRelease;UnitTests</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>GODOT;GODOT_WINDOWS;GODOT_PC;TRACE;DEBUG;TOOLS;</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ExportDebug' ">
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ExportRelease' ">
+    <DefineConstants>GODOT;GODOT_WINDOWS;GODOT_PC;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'UnitTests' ">
+    <DefineConstants>GODOT;GODOT_WINDOWS;GODOT_PC;TRACE;DEBUG</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include="project.godot" />
   </ItemGroup>


### PR DESCRIPTION
We're writing code assuming that we're operating on well-defined unique numeric values - our math isn't designed to work around NaN or infinity. Checking for them can add up, so let's add checks to debug mode only.