### PR TITLE
Turn on nullability warnings and clean up others

### DIFF
--- a/EngineTests/EngineTests.csproj
+++ b/EngineTests/EngineTests.csproj
@@ -11,6 +11,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <FileAlignment>512</FileAlignment>
         <LangVersion>8</LangVersion>
+        <Nullable>warnings</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/engine/calculus/ContinuousMap.cs
+++ b/engine/calculus/ContinuousMap.cs
@@ -20,8 +20,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// A ContinuousMap is an abstract class that defines some function that outputs a value of type `TOut` for each
 	/// input of type `TIn`. Mathematically, this means it defines a mapping from one space to another. For example, a
-	/// ContinuousMap<double, double> defines a function that takes a double value and outputs a double value, such as
-	/// a polynomial function. ContinuousMap<Vector2, double> takes a Vector2 as input and gives a double as output, which
+	/// ContinuousMap{double, double} defines a function that takes a double value and outputs a double value, such as
+	/// a polynomial function. ContinuousMap{Vector2, double} takes a Vector2 as input and gives a double as output, which
 	/// could for instance be used as a height map.
 	public abstract class ContinuousMap<TIn, TOut>
 	{

--- a/engine/calculus/CubicFunction.cs
+++ b/engine/calculus/CubicFunction.cs
@@ -68,28 +68,28 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		}
 		
 		/// <summary>
-		///     Solves the equation \f$d + c x + b x^2 + a x^3 = 0\f$, returning all real values of
+		///     Solves the equation \f$a0 + a1 x + a2 x^2 + a3 x^3 = 0\f$, returning all real values of
 		///		\f$x\f$ for which the equation is true. See https://en.wikipedia.org/wiki/Cubic_equation for the
 		///		algorithm used.
 		/// </summary>
-		public static IEnumerable<double> Solve(double d, double c, double b, double a)
+		public static IEnumerable<double> Solve(double a0, double a1, double a2, double a3)
 		{
-			DebugUtil.AssertFinite(a, nameof(a));
-			DebugUtil.AssertFinite(b, nameof(b));
-			DebugUtil.AssertFinite(c, nameof(c));
-			DebugUtil.AssertFinite(d, nameof(d));
-			if(Math.Abs(a) <= 0.005)
+			DebugUtil.AssertFinite(a3, nameof(a3));
+			DebugUtil.AssertFinite(a2, nameof(a2));
+			DebugUtil.AssertFinite(a1, nameof(a1));
+			DebugUtil.AssertFinite(a0, nameof(a0));
+			if(Math.Abs(a3) <= 0.005)
 			{
-				foreach (double v in QuadraticFunction.Solve(d, c, b))
+				foreach (double v in QuadraticFunction.Solve(a0, a1, a2))
 				{
-					CubicFunction f = new CubicFunction(d, c, b, a);
+					CubicFunction f = new CubicFunction(a0, a1, a2, a3);
 					yield return f.NewtonRaphson(v);
 				}
 				yield break;
 			}
 			
-			double delta0 = b*b - 3.0*a*c;
-			double delta1 = 2.0*b*b*b - 9.0*a*b*c + 27.0*a*a*d;
+			double delta0 = a2*a2 - 3.0*a3*a1;
+			double delta1 = 2.0*a2*a2*a2 - 9.0*a3*a2*a1 + 27.0*a3*a3*a0;
 			
 			Complex p1 = Complex.Sqrt(delta1*delta1 - 4.0*delta0*delta0*delta0);
 			
@@ -97,15 +97,15 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			// zero, we must choose the opposite sign to make it nonzero:
 			Complex p2 = delta1 + p1;
 			
-			Complex C = Complex.Pow(0.5*p2, (1.0/3.0));
-			
+			Complex c = Complex.Pow(0.5*p2, (1.0/3.0));
+
 			Complex xi = -0.5 + 0.5*Complex.Sqrt(-3.0);
-			
+
 			List<Complex> roots = new List<Complex>
 			{
-				-1.0/(3.0*a)*(b + C + delta0/C),
-				-1.0/(3.0*a)*(b + xi*C + delta0/(xi*C)),
-				-1.0/(3.0*a)*(b + xi*xi*C + delta0/(xi*xi*C)),
+				-1.0/(3.0*a3)*(a2 + c + delta0/c),
+				-1.0/(3.0*a3)*(a2 + xi*c + delta0/(xi*c)),
+				-1.0/(3.0*a3)*(a2 + xi*xi*c + delta0/(xi*xi*c)),
 			};
 			
 			foreach (Complex root in roots)

--- a/engine/calculus/CubicSpline1D.cs
+++ b/engine/calculus/CubicSpline1D.cs
@@ -17,7 +17,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System;
-using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -39,7 +38,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///     Construct a cubic spline using a set of input points.
 		/// 	<example>For example:
 		/// 	<code>
-		/// 		SortedList<double, double> splinePoints = new SortedList<double, double>();
+		/// 		SortedList{double, double} splinePoints = new SortedList{double, double}();
 		/// 		splinePoints.Add(0.0f, 1.1f);
 		/// 		splinePoints.Add(0.3f, 0.4f);
 		/// 		splinePoints.Add(1.0f, 2.0f);

--- a/engine/calculus/DerivableFunction.cs
+++ b/engine/calculus/DerivableFunction.cs
@@ -17,10 +17,11 @@
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
-	/// Interface representing an arbitrary curve that calculates values in some output space given a single double
-	/// input parameter.
+	/// Interface representing an function curve that calculates values in some output space given values in some
+	/// input space. Derivatives of this function can be calculated.
 	/// </summary>
-	/// <typeparam name="TOut">Type representing the output space of this curve.</typeparam>
+	/// <typeparam name="TIn">Type representing the input space of this function.</typeparam>
+	/// <typeparam name="TOut">Type representing the output space of this function.</typeparam>
 	public abstract class DerivableFunction<TIn, TOut> : ContinuousMap<TIn, TOut>
 	{
 		/// <summary>
@@ -35,21 +36,20 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <param name="x">Location to calculate the derivative at.</param>
 		/// <param name="derivative">The degree of derivative to calculate.</param>
 		/// <returns>The given derivative of this curve at x.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// 	The value that is sampled must lie between or on the outermost points on which the function is defined.
 		/// 	If <c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
 		public abstract TOut GetNthDerivativeAt(TIn x, uint derivative);
 
 		/// <summary>
-		/// Calculate the first derivative of this curve at the provided location.
+		/// Calculate the first derivative of this derivable function at the provided location.
 		/// <see cref="ICurve{TOut}.GetDerivativeAt"/>
 		/// </summary>
-		/// <param name="curve">This curve to calculate a derivative on.</param>
 		/// <param name="x">Location to calculate the curve's first derivative at.</param>
 		/// <typeparam name="TOut">Output point type of the curve.</typeparam>
 		/// <returns>The first derivative of this curve at the specified location.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">
+		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// 	The value that is sampled must lie between or on the outermost points on which the function is defined.
 		/// 	If <c>x</c> is outside that domain, an <c>ArgumentOutOfRangeException</c> is thrown.
 		/// </exception>
@@ -63,8 +63,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// <summary>
 		/// Gradually approach the root of a derivable function using the Newton-Raphson iterative numerical method.
 		/// </summary>
+		/// <param name="self"> Function to calculate a root for.</param>
 		/// <param name="start">Point at which to start searching for a root. For best results, this starting point must
 		/// be close to the root.</param>
+		/// <param name="iterations"> Number of iterations of Newton-Raphson approximation to use.</param>
 		public static double NewtonRaphson(this DerivableFunction<double, double> self,
 			double start,
 			int iterations = DefaultNewtonRaphsonIterations)

--- a/engine/calculus/DerivableFunction.cs
+++ b/engine/calculus/DerivableFunction.cs
@@ -17,7 +17,7 @@
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
-	/// Interface representing an function curve that calculates values in some output space given values in some
+	/// Interface representing a curve function that calculates values in some output space given values in some
 	/// input space. Derivatives of this function can be calculated.
 	/// </summary>
 	/// <typeparam name="TIn">Type representing the input space of this function.</typeparam>

--- a/engine/calculus/DomainToVector2.cs
+++ b/engine/calculus/DomainToVector2.cs
@@ -19,11 +19,11 @@ using GlmSharp;
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
-	///     <c>DomainToVector2<TOut></c> allows a function on a lower-dimensional domain to be used in places that
+	///     <c>DomainToVector2{TOut}</c> allows a function on a lower-dimensional domain to be used in places that
 	///		expect a higher-dimensional domain. For example, one might want to use a 1D function to describe the
 	///		height of a 2D plane along just a single axis (such as the shape of a corrugated sheet). Since the 2D
 	///		plane expects a 2D function to describe its height, one cannot use a 1D function to describe its height
-	///		properly, since it is unknown which axis the function should use. <c>DomainToVector2<TOut></c> solves this
+	///		properly, since it is unknown which axis the function should use. <c>DomainToVector2{TOut}</c> solves this
 	///		issue by stretching a 1D function onto a 2D domain.
 	/// </summary>
 	/// <param name="direction">
@@ -39,10 +39,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	<example>For example:
 		/// 	<code>
 		///			// Define an arbitrary 1D function:
-		/// 		ContinuousMap<float, float> lineFunction = new QuadraticFunction(1.0f, 1.0f, 1.0f);
+		/// 		ContinuousMap{float, float} lineFunction = new QuadraticFunction(1.0f, 1.0f, 1.0f);
 		///			
 		///			Vector2 direction = new Vector2(0.0f, 1.0f); // Let the 2D function vary along the y-axis.
-		/// 		ContinuousMap<Vector2, float> planeFunction = new DomainToVector2<float>(direction, function);
+		/// 		ContinuousMap{Vector2, float} planeFunction = new DomainToVector2{float}(direction, function);
 		/// 	</code>
 		/// 	creates a 2D function described by a 1D quadratic function along the y-axis. The x-axis of the resulting
 		///		function is therefore constant, while the output value varies along the y-axis, as specified by

--- a/engine/calculus/LinearSpline1D.cs
+++ b/engine/calculus/LinearSpline1D.cs
@@ -16,7 +16,6 @@
 
 using System.Collections.Generic;
 using System;
-using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -29,14 +28,13 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class LinearSpline1D : RaytraceableFunction1D
 	{
-		private double[] _parameters;
 		public SortedPointsList<double> Points { get; }
 		
 		/// <summary>
 		///     Construct a linear spline using a set of input points.
 		/// 	<example>For example:
 		/// 	<code>
-		/// 		SortedList<double, double> splinePoints = new SortedList<double, double>();
+		/// 		SortedList{double, double} splinePoints = new SortedList{double, double}();
 		/// 		splinePoints.Add(0.0f, 1.1f);
 		/// 		splinePoints.Add(0.3f, 0.4f);
 		/// 		splinePoints.Add(1.0f, 2.0f);
@@ -68,7 +66,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			DebugUtil.AssertAllFinite(Points, nameof(Points));
 
 			// Calculate the coefficients for each segment of the spline:
-			_parameters = new double[points.Count];
+			var parameters = new double[points.Count];
 
 			// Recursively find the _parameters:
 			for (int i = 1; i < points.Count; i++)
@@ -76,9 +74,9 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				double dx = Points.Key[i] - Points.Key[i - 1];
 				double dy = Points.Value[i] - Points.Value[i - 1];
 
-				_parameters[i] = dy / dx;
+				parameters[i] = dy / dx;
 			}
-			DebugUtil.AssertAllFinite(_parameters, nameof(_parameters));
+			DebugUtil.AssertAllFinite(parameters, nameof(parameters));
 		}
 
 		/// <summary>
@@ -134,17 +132,17 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 
 			double slope = dy / dx;
 
-			double local_x = x - x1;
+			double localX = x - x1;
 
-			double local_y = local_x * slope;
-			double global_y = local_y + y1;
+			double localY = localX * slope;
+			double globalY = localY + y1;
 
 			// Return the result of evaluating a derivative function, depending on the derivative level:
 			switch (derivative)
 			{
 				case 0:
-					DebugUtil.AssertFinite(global_y, nameof(global_y));
-					return global_y;
+					DebugUtil.AssertFinite(globalY, nameof(globalY));
+					return globalY;
 				case 1:
 					DebugUtil.AssertFinite(slope, nameof(slope));
 					return slope;

--- a/engine/calculus/LinearSpline1D.cs
+++ b/engine/calculus/LinearSpline1D.cs
@@ -64,19 +64,6 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			
 			Points = new SortedPointsList<double>(points);
 			DebugUtil.AssertAllFinite(Points, nameof(Points));
-
-			// Calculate the coefficients for each segment of the spline:
-			var parameters = new double[points.Count];
-
-			// Recursively find the _parameters:
-			for (int i = 1; i < points.Count; i++)
-			{
-				double dx = Points.Key[i] - Points.Key[i - 1];
-				double dy = Points.Value[i] - Points.Value[i - 1];
-
-				parameters[i] = dy / dx;
-			}
-			DebugUtil.AssertAllFinite(parameters, nameof(parameters));
 		}
 
 		/// <summary>

--- a/engine/calculus/MoldCastMap.cs
+++ b/engine/calculus/MoldCastMap.cs
@@ -40,30 +40,30 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// 	The surface from which the rays are cast. A ray is cast out of each point on the surface in the
 		/// 	direction of the surface's normal.
 		/// </summary>
-		private readonly Surface raycastSurface;
+		private readonly Surface _raycastSurface;
 		
 		/// <summary>
 		/// 	The surface that defines the mold. Rays that are cast are checked whether they intersect this surface.
 		/// </summary>
-		private readonly IRaytraceableSurface moldSurface;
+		private readonly IRaytraceableSurface _moldSurface;
 		
 		/// <summary>
 		/// 	The height map that is returned when a ray does not intersect the moldSurface. This happens when the ray
 		/// 	has missed the mold surface and shoots off to infinity. When that happens, return the length of
 		/// 	defaultRadius instead, so that the heightmap is still defined.
 		/// </summary>
-		private readonly ContinuousMap<dvec2, double> defaultRadius;
+		private readonly ContinuousMap<dvec2, double> _defaultRadius;
 		
 		/// <summary>
 		/// 	The direction along the normal of the raycastSurface from which to cast each ray. This could either be
 		/// 	outwards from the surface, or in the opposite direction.
 		/// </summary>
-		private readonly RayCastDirection direction;
+		private readonly RayCastDirection _direction;
 		
 		/// <summary>
 		/// 	The maximum ray length before a ray is considered to be out of bounds.
 		/// </summary>
-		private readonly double maxDistance;
+		private readonly double _maxDistance;
 		
 		/// <summary>
 		/// 	Construct a new MoldCastMap from a curve.
@@ -128,27 +128,27 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 								RayCastDirection direction = RayCastDirection.Outwards,
 								double maxDistance = Double.PositiveInfinity)
 		{
-			this.raycastSurface = raycastSurface;
-			this.moldSurface = moldSurface;
-			this.defaultRadius = defaultRadius;
-			this.direction = direction;
-			this.maxDistance = maxDistance;
+			this._raycastSurface = raycastSurface;
+			this._moldSurface = moldSurface;
+			this._defaultRadius = defaultRadius;
+			this._direction = direction;
+			this._maxDistance = maxDistance;
 		}
 		
 		/// <inheritdoc />
 		public override double GetValueAt(dvec2 uv)
 		{
 			DebugUtil.AssertAllFinite(uv, nameof(uv));
-			double directionSign = (direction == RayCastDirection.Outwards) ? 1.0 : -1.0;
+			double directionSign = (_direction == RayCastDirection.Outwards) ? 1.0 : -1.0;
 
-			Ray ray = new Ray(raycastSurface.GetPositionAt(uv), directionSign*raycastSurface.GetNormalAt(uv).Normalized);
-			double intersectionRadius = moldSurface.RayIntersect(ray);
+			Ray ray = new Ray(_raycastSurface.GetPositionAt(uv), directionSign*_raycastSurface.GetNormalAt(uv).Normalized);
+			double intersectionRadius = _moldSurface.RayIntersect(ray);
 			
-			if (Math.Abs(intersectionRadius) <= maxDistance)
+			if (Math.Abs(intersectionRadius) <= _maxDistance)
 			{
 				return intersectionRadius;
 			} else {
-				return defaultRadius.GetValueAt(uv);
+				return _defaultRadius.GetValueAt(uv);
 			}
 		}
 	}

--- a/engine/calculus/MutablePair.cs
+++ b/engine/calculus/MutablePair.cs
@@ -59,8 +59,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
         /// <summary>
         /// Set both Location and Value with only one callback.
         /// </summary>
-        /// <param name="x">New Location value for the point.</param>
-        /// <param name="y">New Value value for the point.</param>
+        /// <param name="location">New Location value for the point.</param>
+        /// <param name="value">New Value value for the point.</param>
         public void Set(double location, double value)
         {
             _location = location;

--- a/engine/calculus/QuadraticFunction.cs
+++ b/engine/calculus/QuadraticFunction.cs
@@ -16,7 +16,6 @@
 
 using System.Collections.Generic;
 using System;
-using System.Diagnostics;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {

--- a/engine/calculus/QuadraticSpline1D.cs
+++ b/engine/calculus/QuadraticSpline1D.cs
@@ -36,7 +36,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		///     Construct a quadratic spline using a set of input points.
 		/// 	<example>For example:
 		/// 	<code>
-		/// 		SortedList<double, double> splinePoints = new SortedList<double, double>();
+		/// 		SortedList{double, double} splinePoints = new SortedList{double, double}();
 		/// 		splinePoints.Add(0.0f, 1.1f);
 		/// 		splinePoints.Add(0.3f, 0.4f);
 		/// 		splinePoints.Add(1.0f, 2.0f);
@@ -192,16 +192,16 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 				double a2 = -a*div*div;
 
 				// Substitute z = z0 + c t:
-				double A0 = a0 + a1*z0 + a2*z0*z0;
-				double A1 = (a1 + 2.0*a2*z0)*c;
-				double A2 = a2*c*c;
+				double q0 = a0 + a1*z0 + a2*z0*z0;
+				double q1 = (a1 + 2.0*a2*z0)*c;
+				double q2 = a2*c*c;
 
 				// Find the quartic polynomial to solve:
-				double p0 = surfaceFunction.a0 - A0*A0;
-				double p1 = surfaceFunction.a1 - 2.0*A0*A1;
-				double p2 = surfaceFunction.a2 - (2.0*A0*A2 + A1*A1);
-				double p3 = surfaceFunction.a3 - 2.0*A1*A2;
-				double p4 = surfaceFunction.a4 - A2*A2;
+				double p0 = surfaceFunction.A0 - q0*q0;
+				double p1 = surfaceFunction.A1 - 2.0*q0*q1;
+				double p2 = surfaceFunction.A2 - (2.0*q0*q2 + q1*q1);
+				double p3 = surfaceFunction.A3 - 2.0*q1*q2;
+				double p4 = surfaceFunction.A4 - q2*q2;
 
 				// Solve the quartic polynomial:
 				IEnumerable<double> intersections = QuarticFunction.Solve(p0, p1, p2, p3, p4);

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -17,9 +17,6 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System;
-using System.Configuration;
-using System.Diagnostics;
-using System.Text;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -30,11 +27,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// </summary>
 	public class QuarticFunction : DerivableFunction<double, double>
 	{
-		public double a0 { get; }
-		public double a1 { get; }
-		public double a2 { get; }
-		public double a3 { get; }
-		public double a4 { get; }
+		public double A0 { get; }
+		public double A1 { get; }
+		public double A2 { get; }
+		public double A3 { get; }
+		public double A4 { get; }
 		
 		/// <summary>
 		///     A quartic function defined by \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3 + a_4 x^4\f$.
@@ -43,11 +40,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		public QuarticFunction(double a0, double a1, double a2, double a3, double a4)
 		{
 			DebugUtil.AssertAllFinite(new double[]{a0, a1, a2, a3, a4}, "a");
-			this.a0 = a0;
-			this.a1 = a1;
-			this.a2 = a2;
-			this.a3 = a3;
-			this.a4 = a4;
+			this.A0 = a0;
+			this.A1 = a1;
+			this.A2 = a2;
+			this.A3 = a3;
+			this.A4 = a4;
 		}
 		
 		public override double GetNthDerivativeAt(double x, uint derivative)
@@ -56,11 +53,11 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			// Return a different function depending on the derivative level:
 			switch (derivative)
 			{
-				case 0: return a0 + a1*x + a2*x*x + a3*x*x*x + a4*x*x*x*x;
-				case 1: return a1 + 2.0*a2*x + 3.0*a3*x*x + 4.0*a4*x*x*x;
-				case 2: return 2.0*a2 + 6.0*a3*x + 12.0*a4*x*x;
-				case 3: return 6.0*a3 + 24.0*a4*x;
-				case 4: return 24.0*a4;
+				case 0: return A0 + A1*x + A2*x*x + A3*x*x*x + A4*x*x*x*x;
+				case 1: return A1 + 2.0*A2*x + 3.0*A3*x*x + 4.0*A4*x*x*x;
+				case 2: return 2.0*A2 + 6.0*A3*x + 12.0*A4*x*x;
+				case 3: return 6.0*A3 + 24.0*A4*x;
+				case 4: return 24.0*A4;
 				default: return 0.0;
 			}
 		}
@@ -70,15 +67,10 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		{
 			return GetNthDerivativeAt(x, 0);
 		}
-		
-		public double GetDerivativeAt(double x)
-		{
-			return GetNthDerivativeAt(x, 1);
-		}
-		
+
 		public IEnumerable<double> Roots()
 		{
-			return QuarticFunction.Solve(a0, a1, a2, a3, a4);
+			return QuarticFunction.Solve(A0, A1, A2, A3, A4);
 		}
 		
 		/// <summary>

--- a/engine/calculus/ShiftedMap2D.cs
+++ b/engine/calculus/ShiftedMap2D.cs
@@ -19,7 +19,7 @@ using GlmSharp;
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
 	/// <summary>
-	/// 	<c>ShiftedMap2D<TOut></c> shifts the domain of a 2D map such that the values are taken at
+	/// 	<c>ShiftedMap2D{TOut}</c> shifts the domain of a 2D map such that the values are taken at
 	/// 	`Shift + dvec2.Multiply(Stretch, uv)`.
 	/// </summary>
 	public class ShiftedMap2D<TOut> : ContinuousMap<dvec2, TOut>

--- a/engine/engine.csproj
+++ b/engine/engine.csproj
@@ -5,6 +5,7 @@
     <Platforms>AnyCPU</Platforms>
     <LangVersion>8</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/engine/geometry/Cylinder.cs
+++ b/engine/geometry/Cylinder.cs
@@ -82,7 +82,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			this.CenterCurve = centerCurve;
 			this.Radius = radius;
 			this.StartAngle = 0.0;
-			this.EndAngle = 2.0 * (double)Math.PI;
+			this.EndAngle = 2.0 * Math.PI;
 		}
 		
 		/// <summary>
@@ -220,7 +220,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			}
 			var roughs = ParallelEnumerable.Range(0, resolutionV + 1).AsOrdered().SelectMany((j =>
 			{
-				double v = (double) j / (double) resolutionV;
+				double v = j / (double) resolutionV;
 
 				// Find the values at each ring:
 				dvec3 curveTangent = CenterCurve.GetTangentAt(v).Normalized;
@@ -234,12 +234,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 
 				return Enumerable.Range(0, resolutionU).Select((i) =>
 				{
-					double u = startAngle + (endAngle - startAngle) * (double) i / (double) resolutionU;
+					double u = startAngle + (endAngle - startAngle) * i / resolutionU;
 
 					double radius = Radius.GetValueAt(new dvec2(u, v));
 
 					// Calculate the position of the rings of vertices:
-					dvec3 surfaceNormal = (double) Math.Cos(u) * curveNormal + (double) Math.Sin(u) * curveBinormal;
+					dvec3 surfaceNormal = Math.Cos(u) * curveNormal + Math.Sin(u) * curveBinormal;
 					dvec3 surfacePosition = translation + radius * surfaceNormal;
 					return new Vertex((vec3)surfacePosition, (vec3)surfaceNormal);
 				});

--- a/engine/geometry/Hemisphere.cs
+++ b/engine/geometry/Hemisphere.cs
@@ -178,8 +178,6 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			List<Vertex> output = new List<Vertex>(CalculateVertexCount(resolutionU, resolutionV));
 			
 			// Load all required variables:
-			// dvec3 up = dvec3.UnitZ;
-			
 			dvec3 pointTangent = Direction;
 			dvec3 pointNormal = Normal;
 			dvec3 pointBinormal = Binormal;

--- a/engine/geometry/Hemisphere.cs
+++ b/engine/geometry/Hemisphere.cs
@@ -178,7 +178,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 			List<Vertex> output = new List<Vertex>(CalculateVertexCount(resolutionU, resolutionV));
 			
 			// Load all required variables:
-			dvec3 up = dvec3.UnitZ;
+			// dvec3 up = dvec3.UnitZ;
 			
 			dvec3 pointTangent = Direction;
 			dvec3 pointNormal = Normal;

--- a/engine/geometry/Ray.cs
+++ b/engine/geometry/Ray.cs
@@ -28,13 +28,13 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		/// </summary>
 		public dvec3 StartPosition { get; set; }
 		
-		dvec3 direction;
+		dvec3 _direction;
 		/// <summary>
 		///		The direction in which the ray is cast. The direction becomes normalized on assignment.
 		/// </summary>
 		public dvec3 Direction {
-			get { return direction; }
-			set { direction = value.Normalized; }
+			get => _direction;
+			set => _direction = value.Normalized;
 		}
 		
 		/// <summary>
@@ -49,7 +49,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Geometry
 		public Ray(dvec3 rayStart, dvec3 rayDirection)
 		{
 			StartPosition = rayStart;
-			direction = rayDirection.Normalized;
+			_direction = rayDirection.Normalized;
 		}
 	}
 }

--- a/gui/AnatomyProject.csproj
+++ b/gui/AnatomyProject.csproj
@@ -5,6 +5,7 @@
     <Platforms>AnyCPU</Platforms>
     <LangVersion>8</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>GODOT;GODOT_WINDOWS;GODOT_PC;TRACE;DEBUG;TOOLS;</DefineConstants>

--- a/gui/Camera.cs
+++ b/gui/Camera.cs
@@ -29,18 +29,18 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 		/// <summary>
 		/// 	The target position that the camera is currently looking at.
 		/// </summary>
-		private Vector3 focusPosition;
+		private Vector3 _focusPosition;
 		
 		/// <summary>
 		/// 	The angular position from which the camera looks at the target.
 		/// 	x is the horizontal orientation, y is the vertical orientation.
 		/// </summary>
-		private Vector2 angularPosition;
+		private Vector2 _angularPosition;
 		
 		/// <summary>
 		/// 	The distance between the camera and the target.
 		/// </summary>
-		private float distanceFromFocus = 10.0f;
+		private float _distanceFromFocus = 10.0f;
 		
 		/// <summary>
 		/// 	The speed at which scrolling will move the camera closer or further away from
@@ -68,8 +68,8 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 		/// </summary>
 		public override void _Ready()
 		{
-			focusPosition = new Vector3(0.0f, 0.0f, 0.0f);
-			angularPosition = new Vector2(0.0f, 0.5f*Mathf.Pi);
+			_focusPosition = new Vector3(0.0f, 0.0f, 0.0f);
+			_angularPosition = new Vector2(0.0f, 0.5f*Mathf.Pi);
 		}
 		
 		/// <summary>
@@ -83,11 +83,11 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 				if (eventMouseButton.IsPressed()){
 					if (eventMouseButton.ButtonIndex == (int)ButtonList.WheelUp){
 						// Divide by the zoom factor to zoom in:
-						distanceFromFocus /= zoomFactor;
+						_distanceFromFocus /= zoomFactor;
 					}
 					if (eventMouseButton.ButtonIndex == (int)ButtonList.WheelDown){
 						// Multiply by the zoom factor to zoom out:
-						distanceFromFocus *= zoomFactor;
+						_distanceFromFocus *= zoomFactor;
 					}
 				}
 			}
@@ -97,30 +97,30 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 				{
 					// If the user moves the cursor while holding the scrollwheel button and holding
 					// the Shift key, move the focus (target) position:
-					Vector3 screenNormal = (Translation - focusPosition).Normalized();
+					Vector3 screenNormal = (Translation - _focusPosition).Normalized();
 					Vector3 screenRight = screenNormal.Cross(Vector3.Up).Normalized();
 					Vector3 screenUp = -screenNormal.Cross(screenRight).Normalized();
-					float speed = movementSpeed*distanceFromFocus;
-					focusPosition += speed*eventMouseMotion.Relative.x*screenRight;
-					focusPosition += speed*eventMouseMotion.Relative.y*screenUp;
+					float speed = movementSpeed*_distanceFromFocus;
+					_focusPosition += speed*eventMouseMotion.Relative.x*screenRight;
+					_focusPosition += speed*eventMouseMotion.Relative.y*screenUp;
 				} else if (Input.IsMouseButtonPressed(3))
 				{
 					// If the user moves the cursor while holding the scrollwheel button without
 					// modifiers, rotate the camera around the target:
-					angularPosition.x -= horizontalSpeed*eventMouseMotion.Relative.x;
-					angularPosition.y -= verticalSpeed*eventMouseMotion.Relative.y;
+					_angularPosition.x -= horizontalSpeed*eventMouseMotion.Relative.x;
+					_angularPosition.y -= verticalSpeed*eventMouseMotion.Relative.y;
 				}
 			}
 			
 			// Implement Gimbal lock:
-			double u = angularPosition.x;
-			double v = Mathf.Max(Mathf.Min(0.999f*Mathf.Pi, angularPosition.y), 0.001f);
+			double u = _angularPosition.x;
+			double v = Mathf.Max(Mathf.Min(0.999f*Mathf.Pi, _angularPosition.y), 0.001f);
 			
 			// Calculate the 3D camera position from the angular position:
-			Vector3 position = distanceFromFocus*(new Vector3((float)(Math.Sin(v)*Math.Sin(u)), (float)Math.Cos(v), (float)(Math.Sin(v)*Math.Cos(u))));
+			Vector3 position = _distanceFromFocus*(new Vector3((float)(Math.Sin(v)*Math.Sin(u)), (float)Math.Cos(v), (float)(Math.Sin(v)*Math.Cos(u))));
 			
 			// Set the camera's position and rotation:
-			LookAtFromPosition(focusPosition + position, focusPosition, Vector3.Up );
+			LookAtFromPosition(_focusPosition + position, _focusPosition, Vector3.Up );
 		}
 	}
 }

--- a/gui/ExampleBone.cs
+++ b/gui/ExampleBone.cs
@@ -44,14 +44,16 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			LinearSpline1D boneRadius = new LinearSpline1D(radiusPoints);
 
 			// Define the center curve of the long bone:
+			/*
 			SortedList<double, dvec3> centerPoints = new SortedList<double, dvec3>();
 			centerPoints.Add(0.0f, new dvec3(0.0f, 0.0f, 2.7f));
 			centerPoints.Add(0.25f, new dvec3(-0.3f, -0.5f, 1.0f));
 			centerPoints.Add(0.5f, new dvec3(0.3f, 1.0f, 0.0f));
 			centerPoints.Add(0.75f, new dvec3(0.8f, 1.0f, -1.0f));
 			centerPoints.Add(1.0f, new dvec3(0.6f, -0.5f, -0.9f));
-			
+
 			SpatialCubicSpline boneCenter = new SpatialCubicSpline(centerPoints);
+			*/
 			
 			// Add first bone:
 			LineSegment centerLine = new LineSegment(new dvec3(0.0f, 0.0f, 0.5f),
@@ -110,7 +112,7 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 									   new dvec3(0.0f, 1.5f, 0.5f));
 			
 			// Add a long bone to the character:
-			skeleton.joints.Add(new Anatomy.Joints.HingeJoint(centerLine, jointSpline, 0.0f, 1.0f*(double)Math.PI));
+			skeleton.joints.Add(new Anatomy.Joints.HingeJoint(centerLine, jointSpline, 0.0, 1.0*Math.PI));
 			
 			// Generate the geometry vertices of the first bone with resolution U=32 and resolution V=32:
 			UVMesh mesh = skeleton.joints[0].GetArticularSurface().GenerateMesh(64, 64);

--- a/gui/GodotMeshConverter.cs
+++ b/gui/GodotMeshConverter.cs
@@ -16,28 +16,28 @@ namespace FreedomOfFormFoundation.AnatomyRenderer
 			
 			int vertexCount = mesh.VertexList.Count;
 			
-			Vector3[] normal_array = new Godot.Vector3[vertexCount];
-			Vector3[] vertex_array = new Godot.Vector3[vertexCount];
-			
+			Vector3[] normalArray = new Vector3[vertexCount];
+			Vector3[] vertexArray = new Vector3[vertexCount];
+
 			// Populate the arrays from the input mesh data:
 			for (int i = 0; i < vertexCount; i++)
 			{
 				vec3 vertex = mesh.VertexList[i].Position;
 				vec3 normal = mesh.VertexList[i].Normal;
-				vertex_array[i] = new Vector3(vertex.x, vertex.y, vertex.z);
-				normal_array[i] = new Vector3(normal.x, normal.y, normal.z);
+				vertexArray[i] = new Vector3(vertex.x, vertex.y, vertex.z);
+				normalArray[i] = new Vector3(normal.x, normal.y, normal.z);
 			}
-			
+
 			// The index list doesn't need to be converted:
-			int[] index_array = mesh.IndexList.ToArray();
-			
+			int[] indexArray = mesh.IndexList.ToArray();
+
 			// Put the data arrays in a larger array for Godot to understand what the arrays represent:
-			arrays[(int)Mesh.ArrayType.Vertex] = vertex_array;
-			arrays[(int)Mesh.ArrayType.Normal] = normal_array;
-			arrays[(int)Mesh.ArrayType.Index] = index_array;
+			arrays[(int)Mesh.ArrayType.Vertex] = vertexArray;
+			arrays[(int)Mesh.ArrayType.Normal] = normalArray;
+			arrays[(int)Mesh.ArrayType.Index] = indexArray;
 			
 			// Finally, upload the mesh to GPU:
-			this.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, arrays);
+			this.AddSurfaceFromArrays(PrimitiveType.Triangles, arrays);
 		}
 	}
 }


### PR DESCRIPTION
The nullability detector didn't see any problems with our existing logic (it will complain more when actual nullability annotations are required) but in looking for them I cleaned up a bunch of other warnings.

The code is still not clean of warnings, but I'm not confident what to do about the other ones, or it's disruptive (changing namespace or rearranging the project), or it looks like it's a warning due to incomplete stub code that should be left in its incomplete state.